### PR TITLE
Systick refactor

### DIFF
--- a/public.h
+++ b/public.h
@@ -43,7 +43,6 @@ extern volatile int gSensorA5_light;
 // provided by sensors_control.cpp
 void sensors_control_setup();
 void print_sensors_control(char mode);
-void update_sensors_control();
 extern char emitter_on;
 
 // provided by distance-moved.cpp

--- a/public.h
+++ b/public.h
@@ -18,10 +18,18 @@ int readFunctionSwitch();
 // ADC channels
 extern volatile int raw_BatteryVolts_adcValue;
 extern volatile int Switch_ADC_value;
+
 extern volatile int gSensorA0_dark;
 extern volatile int gSensorA1_dark;
 extern volatile int gSensorA2_dark;
 extern volatile int gSensorA3_dark;
+extern volatile int gSensorA4_dark;
+extern volatile int gSensorA5_dark;
+
+extern volatile int gSensorA0_light;
+extern volatile int gSensorA1_light;
+extern volatile int gSensorA2_light;
+extern volatile int gSensorA3_light;
 extern volatile int gSensorA4_light;
 extern volatile int gSensorA5_light;
 

--- a/sensors_control.cpp
+++ b/sensors_control.cpp
@@ -118,8 +118,7 @@ void print_sensors_control(char mode) {
     a5_lit = gSensorA5_light;
   }
 
-  if (mode == 'd')  // the default
-  {
+  if (mode == 'd') {  // the default is decimal differences
     Serial.print(max(a0_lit - a0_dark, 0));
     Serial.print(comma);
     Serial.print(max(a1_lit - a1_dark, 0));
@@ -131,15 +130,14 @@ void print_sensors_control(char mode) {
     Serial.print(max(a4_lit - a4_dark, 0));
     Serial.print(comma);
     Serial.print(max(a5_lit - a5_dark, 0));
-  } else if (mode == 'h')  // display as hex values
-  {
+  } else if (mode == 'h') {  // display differences as hex values
     print_hex2(a0_lit - a0_dark);
     print_hex2(a1_lit - a1_dark);
     print_hex2(a2_lit - a2_dark);
     print_hex2(a3_lit - a3_dark);
     print_hex2(a4_lit - a4_dark);
     print_hex2(a5_lit - a5_dark);
-  } else if (mode == 'r') { // 
+  } else if (mode == 'r') { // display both dark and lit values
     Serial.print(a0_dark);
     Serial.print(comma);
     Serial.print(a1_dark);

--- a/sensors_control.cpp
+++ b/sensors_control.cpp
@@ -63,45 +63,7 @@ void analogueSetup() {
 }
 char emitter_on = 1;
 
-void update_sensors_control() {
-  // first read them dark
-  int a0 = analogRead(A0);
-  int a1 = analogRead(A1);
-  int a2 = analogRead(A2);
-  int a3 = analogRead(A3);
-  int a0_ = a0;
-  int a1_ = a1;
-  int a2_ = a2;
-  int a3_ = a3;  // they should read as the same if emitter is off.
 
-  if (emitter_on) {
-    // light them up
-    digitalWriteFast(EMITTER, 1);
-
-    // wait until all the detectors are stable
-    delayMicroseconds(50);
-
-    // now find the differences
-    a0_ = analogRead(A0);
-    a1_ = analogRead(A1);
-    a2_ = analogRead(A2);
-    a3_ = analogRead(A3);
-    gSensorA4_light = analogRead(A4);
-    gSensorA5_light = analogRead(A5);
-    // and go dark again.
-    digitalWriteFast(EMITTER, 0);
-  }
-
-  // make the results available to the rest of the program
-  gSensorA0_dark = a0;
-  gSensorA1_dark = a1;
-  gSensorA2_dark = a2;
-  gSensorA3_dark = a3;
-  gSensorA0_light = a0_;
-  gSensorA1_light = a1_;
-  gSensorA2_light = a2_;
-  gSensorA3_light = a3_;
-}
 
 void sensors_control_setup() {
   pinMode(EMITTER, OUTPUT);

--- a/sensors_control.cpp
+++ b/sensors_control.cpp
@@ -35,15 +35,19 @@
 #include "digitalWriteFast.h"
 #include "hardware_pins.h"
 #include <util/atomic.h>
-
+#include "public.h"
 /***
  * Global variables
  */
 // the current value of the sensors
+
 volatile int gSensorA0_dark;
 volatile int gSensorA1_dark;
 volatile int gSensorA2_dark;
 volatile int gSensorA3_dark;
+volatile int gSensorA4_dark;
+volatile int gSensorA5_dark;
+
 volatile int gSensorA0_light;
 volatile int gSensorA1_light;
 volatile int gSensorA2_light;
@@ -105,73 +109,108 @@ void sensors_control_setup() {
   analogueSetup();               // increase the ADC conversion speed
 }
 
+void print_hex2(int value) {
+  value = constrain(value, 0, 255);
+  Serial.print(value / 16, HEX);
+  Serial.print(value % 16, HEX);
+}
 
 void print_sensors_control(char mode)
 {
-  int gSensorA0_dark_;
-  int gSensorA1_dark_;
-  int gSensorA2_dark_;
-  int gSensorA3_dark_;
-  int gSensorA0_light_;
-  int gSensorA1_light_;
-  int gSensorA2_light_;
-  int gSensorA3_light_;
+  int a0_dark;
+  int a1_dark;
+  int a2_dark;
+  int a3_dark;
+  int a4_dark;
+  int a5_dark;
+  int a0_lit;
+  int a1_lit;
+  int a2_lit;
+  int a3_lit;
+  int a4_lit;
+  int a5_lit;
+  const char comma = ',';
+while(readFunctionSwitch() != 16){
 
   // read the sensors
   ATOMIC_BLOCK(ATOMIC_RESTORESTATE) { 
-    gSensorA0_dark_ = gSensorA0_dark;
-    gSensorA1_dark_ = gSensorA1_dark;
-    gSensorA2_dark_ = gSensorA2_dark;
-    gSensorA3_dark_ = gSensorA3_dark;
-    gSensorA0_light_ = gSensorA0_light;
-    gSensorA1_light_ = gSensorA1_light;
-    gSensorA2_light_ = gSensorA2_light;
-    gSensorA3_light_ = gSensorA3_light;
+    a0_dark = gSensorA0_dark;
+    a0_lit = gSensorA0_light;
   }
-
-  const char comma = ',';
-  if(mode == 'd')
-  {
-    Serial.print(max(gSensorA0_light_ - gSensorA0_dark_, 0));
-    Serial.print(comma);
-    Serial.print(max(gSensorA1_light_ - gSensorA1_dark_, 0));
-    Serial.print(comma);
-    Serial.print(max(gSensorA2_light_ - gSensorA2_dark_, 0));
-    Serial.print(comma);
-    Serial.print(max(gSensorA3_light_ - gSensorA3_dark_, 0));
+  ATOMIC_BLOCK(ATOMIC_RESTORESTATE) { 
+    a1_dark = gSensorA1_dark;
+    a1_lit = gSensorA1_light;
   }
-  else if(mode == 'h')
+  ATOMIC_BLOCK(ATOMIC_RESTORESTATE) { 
+    a2_dark = gSensorA2_dark;
+    a2_lit = gSensorA2_light;
+  }
+  ATOMIC_BLOCK(ATOMIC_RESTORESTATE) { 
+    a3_dark = gSensorA3_dark;
+    a3_lit = gSensorA3_light;
+  }
+  ATOMIC_BLOCK(ATOMIC_RESTORESTATE) { 
+    a4_dark = gSensorA4_dark;
+    a4_lit = gSensorA4_light;
+  }
+  ATOMIC_BLOCK(ATOMIC_RESTORESTATE) { 
+    a5_dark = gSensorA5_dark;
+    a5_lit = gSensorA5_light;
+  }
+  
+  if(mode == 'd') // the default
   {
-    gSensorA0_light_ = constrain(gSensorA0_light_-gSensorA0_dark_, 0, 255);
-    if(gSensorA0_light_ < 0x10) { Serial.print('0'); }
-    Serial.print(gSensorA0_light_, HEX);
-    gSensorA1_light_ = constrain(gSensorA1_light_-gSensorA1_dark_, 0, 255);
-    if(gSensorA1_light_ < 0x10) { Serial.print('0'); }
-    Serial.print(gSensorA1_light_, HEX);
-    gSensorA2_light_ = constrain(gSensorA2_light_-gSensorA2_dark_, 0, 255);
-    if(gSensorA2_light_ < 0x10) { Serial.print('0'); }
-    Serial.print(gSensorA2_light_, HEX);
-    gSensorA3_light_ = constrain(gSensorA3_light_-gSensorA3_dark_, 0, 255);
-    if(gSensorA3_light_ < 0x10) { Serial.print('0'); }
-    Serial.print(gSensorA3_light_, HEX);
+    Serial.print(max(a0_lit - a0_dark, 0));
+    Serial.print(comma);
+    Serial.print(max(a1_lit - a1_dark, 0));
+    Serial.print(comma);
+    Serial.print(max(a2_lit - a2_dark, 0));
+    Serial.print(comma);
+    Serial.print(max(a3_lit - a3_dark, 0));
+    Serial.print(comma);
+    Serial.print(max(a4_lit - a4_dark, 0));
+    Serial.print(comma);
+    Serial.print(max(a5_lit - a5_dark, 0));
+  }
+  else if(mode == 'h') // display as hex values
+  {
+    uint8_t diff;
+    print_hex2(a0_lit-a0_dark);
+    print_hex2(a1_lit-a1_dark);
+    print_hex2(a2_lit-a2_dark);
+    print_hex2(a3_lit-a3_dark);
+    print_hex2(a4_lit-a4_dark);
+    print_hex2(a5_lit-a5_dark);
   }
   else if(mode == 'r')
   {
-    Serial.print(gSensorA0_dark_);
+    Serial.print(a0_dark);
     Serial.print(comma);
-    Serial.print(gSensorA1_dark_);
+    Serial.print(a1_dark);
     Serial.print(comma);
-    Serial.print(gSensorA2_dark_);
+    Serial.print(a2_dark);
     Serial.print(comma);
-    Serial.print(gSensorA3_dark_);
+    Serial.print(a3_dark);
     Serial.print(comma);
-    Serial.print(gSensorA0_light_);
+    Serial.print(a4_dark);
     Serial.print(comma);
-    Serial.print(gSensorA1_light_);
+    Serial.print(a5_dark);
     Serial.print(comma);
-    Serial.print(gSensorA2_light_);
+    Serial.print(' ');
+    Serial.print(' ');
+    Serial.print(a0_lit);
     Serial.print(comma);
-    Serial.print(gSensorA3_light_);
+    Serial.print(a1_lit);
+    Serial.print(comma);
+    Serial.print(a2_lit);
+    Serial.print(comma);
+    Serial.print(a3_lit);
+    Serial.print(comma);
+    Serial.print(a4_lit);
+    Serial.print(comma);
+    Serial.print(a5_lit);
   }
   Serial.println();
+  delay(100);
+}
 }

--- a/sensors_control.cpp
+++ b/sensors_control.cpp
@@ -77,8 +77,7 @@ void print_hex2(int value) {
   Serial.print(value % 16, HEX);
 }
 
-void print_sensors_control(char mode)
-{
+void print_sensors_control(char mode) {
   int a0_dark;
   int a1_dark;
   int a2_dark;
@@ -92,35 +91,34 @@ void print_sensors_control(char mode)
   int a4_lit;
   int a5_lit;
   const char comma = ',';
-while(readFunctionSwitch() != 16){
 
   // read the sensors
-  ATOMIC_BLOCK(ATOMIC_RESTORESTATE) { 
+  ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
     a0_dark = gSensorA0_dark;
     a0_lit = gSensorA0_light;
   }
-  ATOMIC_BLOCK(ATOMIC_RESTORESTATE) { 
+  ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
     a1_dark = gSensorA1_dark;
     a1_lit = gSensorA1_light;
   }
-  ATOMIC_BLOCK(ATOMIC_RESTORESTATE) { 
+  ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
     a2_dark = gSensorA2_dark;
     a2_lit = gSensorA2_light;
   }
-  ATOMIC_BLOCK(ATOMIC_RESTORESTATE) { 
+  ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
     a3_dark = gSensorA3_dark;
     a3_lit = gSensorA3_light;
   }
-  ATOMIC_BLOCK(ATOMIC_RESTORESTATE) { 
+  ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
     a4_dark = gSensorA4_dark;
     a4_lit = gSensorA4_light;
   }
-  ATOMIC_BLOCK(ATOMIC_RESTORESTATE) { 
+  ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
     a5_dark = gSensorA5_dark;
     a5_lit = gSensorA5_light;
   }
-  
-  if(mode == 'd') // the default
+
+  if (mode == 'd')  // the default
   {
     Serial.print(max(a0_lit - a0_dark, 0));
     Serial.print(comma);
@@ -133,19 +131,15 @@ while(readFunctionSwitch() != 16){
     Serial.print(max(a4_lit - a4_dark, 0));
     Serial.print(comma);
     Serial.print(max(a5_lit - a5_dark, 0));
-  }
-  else if(mode == 'h') // display as hex values
+  } else if (mode == 'h')  // display as hex values
   {
-    uint8_t diff;
-    print_hex2(a0_lit-a0_dark);
-    print_hex2(a1_lit-a1_dark);
-    print_hex2(a2_lit-a2_dark);
-    print_hex2(a3_lit-a3_dark);
-    print_hex2(a4_lit-a4_dark);
-    print_hex2(a5_lit-a5_dark);
-  }
-  else if(mode == 'r')
-  {
+    print_hex2(a0_lit - a0_dark);
+    print_hex2(a1_lit - a1_dark);
+    print_hex2(a2_lit - a2_dark);
+    print_hex2(a3_lit - a3_dark);
+    print_hex2(a4_lit - a4_dark);
+    print_hex2(a5_lit - a5_dark);
+  } else if (mode == 'r') { // 
     Serial.print(a0_dark);
     Serial.print(comma);
     Serial.print(a1_dark);
@@ -173,6 +167,4 @@ while(readFunctionSwitch() != 16){
     Serial.print(a5_lit);
   }
   Serial.println();
-  delay(100);
-}
 }

--- a/systick.cpp
+++ b/systick.cpp
@@ -170,7 +170,7 @@ unsigned long t_systick3 = 0;
  * So that high-speed encoder interrupts are not missed each phase
  * should ideally last no more than 10us.
  * 
- * The reason fo rthis apparently arcane technique is that the 
+ * The reason for this apparently arcane technique is that the 
  * ATMEGA328P does not have nested interrupts. At top speed, the 
  * encoders may generate interrupt at more than 20kHz and we cannot
  * afford to miss one. Also, received serial characters must be serviced
@@ -178,20 +178,21 @@ unsigned long t_systick3 = 0;
  * that does everything but takes many tens of microseconds risks
  * lost serial data and encoder pulses.
  *  
- * For testing, the built-in LED is turned on at the start of the interrupt
+ * For testing, the built-in LED can be turned on at the start of the interrupt
  * and off again at the end. This can be used to measure system load.
  * Disable the feature if you want to use the built-in LED for some other 
  * purpose.
- */ 
+ * 
+ */
 ISR(TIMER2_COMPA_vect) {
-  digitalWriteFast(LED_BUILTIN, 1);
+  // digitalWriteFast(LED_BUILTIN, 1);
   systick_phase++;
   if (systick_phase >= 40) {
     systick_phase = 0;
   }
   switch (systick_phase) {
     case 0:
-      // always start conversions as soon as  possible so they get a 
+      // always start conversions as soon as  possible so they get a
       // full 50us to convert
       start_adc(BATTERY_VOLTS);
       delayMicroseconds(40);  // just a long marker for the oscilloscope.
@@ -266,7 +267,7 @@ ISR(TIMER2_COMPA_vect) {
     default:
       break;
   }
-  digitalWriteFast(LED_BUILTIN, 0);
+  // digitalWriteFast(LED_BUILTIN, 0);
   /***
    * Speed control may now need to happen either in short sections here
    * or at the top level of the code. A flag, set in one phase

--- a/systick.cpp
+++ b/systick.cpp
@@ -147,9 +147,8 @@ void setupSystick() {
   bitSet(TCCR2B, CS20);
 
   // set the timer frequency
-  OCR2A = 24;  // (16000000/32/20000)-1 = 24
-  // enable the timer interrupt
-  bitSet(TIMSK2, OCIE2A);
+  OCR2A = 24;              // (16000000/32/20000)-1 = 24
+  bitSet(TIMSK2, OCIE2A);  // enable the timer interrupt
 }
 
 unsigned long t_systick1 = 0;


### PR DESCRIPTION
Systick now runs at 20kHz and samples all six sensor channels as well as the battery and function switch. 

Updates have been made to the sensor display commands as well so that all six channels are displayed. 

Also tucked in is a small change to the hex display of channel data just for a bit of clarity.

As far as I can tell, the outcomes are still the same. 

If you have not already noted this elsewhere, unconnected ADC channels will display a value dependent upon the most recently sampled channel. this could be eliminated in software by setting unused channels to outputs and writing a zero. I think.