### PR TITLE
Clang format files

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,15 @@
+---
+
+BasedOnStyle: LLVM
+UseTab: Never
+IndentWidth: 4
+TabWidth: 4
+BreakBeforeBraces: Allman
+AllowShortIfStatementsOnASingleLine: false
+IndentCaseLabels: false
+ColumnLimit: 0
+AccessModifierOffset: -4
+NamespaceIndentation: All
+FixNamespaceComments: false
+
+...

--- a/digitalWriteFast.h
+++ b/digitalWriteFast.h
@@ -9,386 +9,346 @@
 
 // general macros/defines
 #ifndef BIT_READ
-# define BIT_READ(value, bit)            ((value) &   (1UL << (bit)))
+#define BIT_READ(value, bit) ((value) & (1UL << (bit)))
 #endif
 #ifndef BIT_SET
-# define BIT_SET(value, bit)             ((value) |=  (1UL << (bit)))
+#define BIT_SET(value, bit) ((value) |= (1UL << (bit)))
 #endif
 #ifndef BIT_CLEAR
-# define BIT_CLEAR(value, bit)           ((value) &= ~(1UL << (bit)))
+#define BIT_CLEAR(value, bit) ((value) &= ~(1UL << (bit)))
 #endif
 #ifndef BIT_WRITE
-# define BIT_WRITE(value, bit, bitvalue) (bitvalue ? BIT_SET(value, bit) : BIT_CLEAR(value, bit))
+#define BIT_WRITE(value, bit, bitvalue) (bitvalue ? BIT_SET(value, bit) : BIT_CLEAR(value, bit))
 #endif
 
 #ifndef SWAP
-#define SWAP(x,y) do{ (x)=(x)^(y); (y)=(x)^(y); (x)=(x)^(y); }while(0)
+#define SWAP(x, y)       \
+    do                   \
+    {                    \
+        (x) = (x) ^ (y); \
+        (y) = (x) ^ (y); \
+        (x) = (x) ^ (y); \
+    } while (0)
 #endif
 
 #ifndef DEC
-# define DEC (10)
+#define DEC (10)
 #endif
 #ifndef HEX
-# define HEX (16)
+#define HEX (16)
 #endif
 #ifndef OCT
-# define OCT (8)
+#define OCT (8)
 #endif
 #ifndef BIN
-# define BIN (2)
+#define BIN (2)
 #endif
 
-
 // workarounds for ARM microcontrollers
-#if (!defined(__AVR__) || \
+#if (!defined(__AVR__) ||         \
      defined(ARDUINO_ARCH_SAM) || \
      defined(ARDUINO_ARCH_SAMD))
 
 #ifndef PROGMEM
-# define PROGMEM
+#define PROGMEM
 #endif
 #ifndef PGM_P
-# define PGM_P const char *
+#define PGM_P const char *
 #endif
 #ifndef PSTR
-# define PSTR(str) (str)
+#define PSTR(str) (str)
 #endif
 
 #ifndef memcpy_P
-# define memcpy_P(dest, src, num) memcpy((dest), (src), (num))
+#define memcpy_P(dest, src, num) memcpy((dest), (src), (num))
 #endif
 #ifndef strcpy_P
-# define strcpy_P(dst, src)       strcpy((dst), (src))
+#define strcpy_P(dst, src) strcpy((dst), (src))
 #endif
 #ifndef strcat_P
-# define strcat_P(dst, src)       strcat((dst), (src))
+#define strcat_P(dst, src) strcat((dst), (src))
 #endif
 #ifndef strcmp_P
-# define strcmp_P(a, b)           strcmp((a), (b))
+#define strcmp_P(a, b) strcmp((a), (b))
 #endif
 #ifndef strcasecmp_P
-# define strcasecmp_P(a, b)       strcasecmp((a), (b))
+#define strcasecmp_P(a, b) strcasecmp((a), (b))
 #endif
 #ifndef strncmp_P
-# define strncmp_P(a, b, n)       strncmp((a), (b), (n))
+#define strncmp_P(a, b, n) strncmp((a), (b), (n))
 #endif
 #ifndef strncasecmp_P
-# define strncasecmp_P(a, b, n)   strncasecmp((a), (b), (n))
+#define strncasecmp_P(a, b, n) strncasecmp((a), (b), (n))
 #endif
 #ifndef strstr_P
-# define strstr_P(a, b)           strstr((a), (b))
+#define strstr_P(a, b) strstr((a), (b))
 #endif
 #ifndef strlen_P
-# define strlen_P(a)              strlen((a))
+#define strlen_P(a) strlen((a))
 #endif
 #ifndef sprintf_P
-# define sprintf_P(s, f, ...)     sprintf((s), (f), __VA_ARGS__)
+#define sprintf_P(s, f, ...) sprintf((s), (f), __VA_ARGS__)
 #endif
 
 #ifndef pgm_read_byte
-# define pgm_read_byte(addr)      (*(const unsigned char *)(addr))
+#define pgm_read_byte(addr) (*(const unsigned char *)(addr))
 #endif
 #ifndef pgm_read_word
-# define pgm_read_word(addr)      (*(const unsigned short *)(addr))
+#define pgm_read_word(addr) (*(const unsigned short *)(addr))
 #endif
 #ifndef pgm_read_dword
-# define pgm_read_dword(addr)     (*(const unsigned long *)(addr))
+#define pgm_read_dword(addr) (*(const unsigned long *)(addr))
 #endif
 
 #endif
-
 
 // digital functions
 //#ifndef digitalPinToPortReg
-#define SPI_SW_SS_PIN   (10) //SS on Uno (for software SPI)
+#define SPI_SW_SS_PIN (10)   //SS on Uno (for software SPI)
 #define SPI_SW_MOSI_PIN (11) //MOSI on Uno (for software SPI)
 #define SPI_SW_MISO_PIN (12) //MISO on Uno (for software SPI)
-#define SPI_SW_SCK_PIN  (13) //SCK on Uno (for software SPI)
-
+#define SPI_SW_SCK_PIN (13)  //SCK on Uno (for software SPI)
 
 // --- Arduino Due and SAM3X8E based boards ---
 #if (defined(ARDUINO_SAM_DUE) || \
      defined(__SAM3X8E__))
 
-#define UART_RX_PIN     (0)
-#define UART_TX_PIN     (1)
+#define UART_RX_PIN (0)
+#define UART_TX_PIN (1)
 
-#define I2C_SDA_PIN     (20)
-#define I2C_SCL_PIN     (21)
+#define I2C_SDA_PIN (20)
+#define I2C_SCL_PIN (21)
 
-#define SPI_HW_SS_PIN   (78) //SS0:77, SS1:87, SS2:86, SS3:78
+#define SPI_HW_SS_PIN (78)   //SS0:77, SS1:87, SS2:86, SS3:78
 #define SPI_HW_MOSI_PIN (75) //75
 #define SPI_HW_MISO_PIN (74) //74
-#define SPI_HW_SCK_PIN  (76) //76
-
+#define SPI_HW_SCK_PIN (76)  //76
 
 // --- Arduino Zero and SAMD21G18 based boards ---
 #elif (defined(ARDUINO_SAMD_ZERO) || \
        defined(__SAMD21G18A__))
 
-#define UART_RX_PIN     (0)
-#define UART_TX_PIN     (1)
+#define UART_RX_PIN (0)
+#define UART_TX_PIN (1)
 
-#define I2C_SDA_PIN     (16)
-#define I2C_SCL_PIN     (17)
+#define I2C_SDA_PIN (16)
+#define I2C_SCL_PIN (17)
 
-#define SPI_HW_SS_PIN   (14) //14
+#define SPI_HW_SS_PIN (14)   //14
 #define SPI_HW_MOSI_PIN (21) //21
 #define SPI_HW_MISO_PIN (18) //18
-#define SPI_HW_SCK_PIN  (20) //20
-
+#define SPI_HW_SCK_PIN (20)  //20
 
 // --- Arduino Mega and ATmega128x/256x based boards ---
-#elif (defined(ARDUINO_AVR_MEGA) || \
+#elif (defined(ARDUINO_AVR_MEGA) ||     \
        defined(ARDUINO_AVR_MEGA1280) || \
        defined(ARDUINO_AVR_MEGA2560) || \
-       defined(__AVR_ATmega1280__) || \
-       defined(__AVR_ATmega1281__) || \
-       defined(__AVR_ATmega2560__) || \
+       defined(__AVR_ATmega1280__) ||   \
+       defined(__AVR_ATmega1281__) ||   \
+       defined(__AVR_ATmega2560__) ||   \
        defined(__AVR_ATmega2561__))
 
-#define UART_RX_PIN     (0) //PE0
-#define UART_TX_PIN     (1) //PE1
+#define UART_RX_PIN (0) //PE0
+#define UART_TX_PIN (1) //PE1
 
-#define I2C_SDA_PIN     (20)
-#define I2C_SCL_PIN     (21)
+#define I2C_SDA_PIN (20)
+#define I2C_SCL_PIN (21)
 
-#define SPI_HW_SS_PIN   (53) //PB0
+#define SPI_HW_SS_PIN (53)   //PB0
 #define SPI_HW_MOSI_PIN (51) //PB2
 #define SPI_HW_MISO_PIN (50) //PB3
-#define SPI_HW_SCK_PIN  (52) //PB1
+#define SPI_HW_SCK_PIN (52)  //PB1
 
 #define __digitalPinToPortReg(P) \
-(((P) >= 22 && (P) <= 29) ? &PORTA : \
-((((P) >= 10 && (P) <= 13) || ((P) >= 50 && (P) <= 53)) ? &PORTB : \
-(((P) >= 30 && (P) <= 37) ? &PORTC : \
-((((P) >= 18 && (P) <= 21) || (P) == 38) ? &PORTD : \
-((((P) >= 0 && (P) <= 3) || (P) == 5) ? &PORTE : \
-(((P) >= 54 && (P) <= 61) ? &PORTF : \
-((((P) >= 39 && (P) <= 41) || (P) == 4) ? &PORTG : \
-((((P) >= 6 && (P) <= 9) || (P) == 16 || (P) == 17) ? &PORTH : \
-(((P) == 14 || (P) == 15) ? &PORTJ : \
-(((P) >= 62 && (P) <= 69) ? &PORTK : &PORTL))))))))))
+    (((P) >= 22 && (P) <= 29) ? &PORTA : ((((P) >= 10 && (P) <= 13) || ((P) >= 50 && (P) <= 53)) ? &PORTB : (((P) >= 30 && (P) <= 37) ? &PORTC : ((((P) >= 18 && (P) <= 21) || (P) == 38) ? &PORTD : ((((P) >= 0 && (P) <= 3) || (P) == 5) ? &PORTE : (((P) >= 54 && (P) <= 61) ? &PORTF : ((((P) >= 39 && (P) <= 41) || (P) == 4) ? &PORTG : ((((P) >= 6 && (P) <= 9) || (P) == 16 || (P) == 17) ? &PORTH : (((P) == 14 || (P) == 15) ? &PORTJ : (((P) >= 62 && (P) <= 69) ? &PORTK : &PORTL))))))))))
 
 #define __digitalPinToDDRReg(P) \
-(((P) >= 22 && (P) <= 29) ? &DDRA : \
-((((P) >= 10 && (P) <= 13) || ((P) >= 50 && (P) <= 53)) ? &DDRB : \
-(((P) >= 30 && (P) <= 37) ? &DDRC : \
-((((P) >= 18 && (P) <= 21) || (P) == 38) ? &DDRD : \
-((((P) >= 0 && (P) <= 3) || (P) == 5) ? &DDRE : \
-(((P) >= 54 && (P) <= 61) ? &DDRF : \
-((((P) >= 39 && (P) <= 41) || (P) == 4) ? &DDRG : \
-((((P) >= 6 && (P) <= 9) || (P) == 16 || (P) == 17) ? &DDRH : \
-(((P) == 14 || (P) == 15) ? &DDRJ : \
-(((P) >= 62 && (P) <= 69) ? &DDRK : &DDRL))))))))))
+    (((P) >= 22 && (P) <= 29) ? &DDRA : ((((P) >= 10 && (P) <= 13) || ((P) >= 50 && (P) <= 53)) ? &DDRB : (((P) >= 30 && (P) <= 37) ? &DDRC : ((((P) >= 18 && (P) <= 21) || (P) == 38) ? &DDRD : ((((P) >= 0 && (P) <= 3) || (P) == 5) ? &DDRE : (((P) >= 54 && (P) <= 61) ? &DDRF : ((((P) >= 39 && (P) <= 41) || (P) == 4) ? &DDRG : ((((P) >= 6 && (P) <= 9) || (P) == 16 || (P) == 17) ? &DDRH : (((P) == 14 || (P) == 15) ? &DDRJ : (((P) >= 62 && (P) <= 69) ? &DDRK : &DDRL))))))))))
 
 #define __digitalPinToPINReg(P) \
-(((P) >= 22 && (P) <= 29) ? &PINA : \
-((((P) >= 10 && (P) <= 13) || ((P) >= 50 && (P) <= 53)) ? &PINB : \
-(((P) >= 30 && (P) <= 37) ? &PINC : \
-((((P) >= 18 && (P) <= 21) || (P) == 38) ? &PIND : \
-((((P) >= 0 && (P) <= 3) || (P) == 5) ? &PINE : \
-(((P) >= 54 && (P) <= 61) ? &PINF : \
-((((P) >= 39 && (P) <= 41) || (P) == 4) ? &PING : \
-((((P) >= 6 && (P) <= 9) || (P) == 16 || (P) == 17) ? &PINH : \
-(((P) == 14 || (P) == 15) ? &PINJ : \
-(((P) >= 62 && (P) <= 69) ? &PINK : &PINL))))))))))
+    (((P) >= 22 && (P) <= 29) ? &PINA : ((((P) >= 10 && (P) <= 13) || ((P) >= 50 && (P) <= 53)) ? &PINB : (((P) >= 30 && (P) <= 37) ? &PINC : ((((P) >= 18 && (P) <= 21) || (P) == 38) ? &PIND : ((((P) >= 0 && (P) <= 3) || (P) == 5) ? &PINE : (((P) >= 54 && (P) <= 61) ? &PINF : ((((P) >= 39 && (P) <= 41) || (P) == 4) ? &PING : ((((P) >= 6 && (P) <= 9) || (P) == 16 || (P) == 17) ? &PINH : (((P) == 14 || (P) == 15) ? &PINJ : (((P) >= 62 && (P) <= 69) ? &PINK : &PINL))))))))))
 
 #define __digitalPinToBit(P) \
-(((P) >=  7 && (P) <=  9) ? (P) - 3 : \
-(((P) >= 10 && (P) <= 13) ? (P) - 6 : \
-(((P) >= 22 && (P) <= 29) ? (P) - 22 : \
-(((P) >= 30 && (P) <= 37) ? 37 - (P) : \
-(((P) >= 39 && (P) <= 41) ? 41 - (P) : \
-(((P) >= 42 && (P) <= 49) ? 49 - (P) : \
-(((P) >= 50 && (P) <= 53) ? 53 - (P) : \
-(((P) >= 54 && (P) <= 61) ? (P) - 54 : \
-(((P) >= 62 && (P) <= 69) ? (P) - 62 : \
-(((P) == 0 || (P) == 15 || (P) == 17 || (P) == 21) ? 0 : \
-(((P) == 1 || (P) == 14 || (P) == 16 || (P) == 20) ? 1 : \
-(((P) == 19) ? 2 : \
-(((P) == 5 || (P) == 6 || (P) == 18) ? 3 : \
-(((P) == 2) ? 4 : \
-(((P) == 3 || (P) == 4) ? 5 : 7)))))))))))))))
-
+    (((P) >= 7 && (P) <= 9) ? (P)-3 : (((P) >= 10 && (P) <= 13) ? (P)-6 : (((P) >= 22 && (P) <= 29) ? (P)-22 : (((P) >= 30 && (P) <= 37) ? 37 - (P) : (((P) >= 39 && (P) <= 41) ? 41 - (P) : (((P) >= 42 && (P) <= 49) ? 49 - (P) : (((P) >= 50 && (P) <= 53) ? 53 - (P) : (((P) >= 54 && (P) <= 61) ? (P)-54 : (((P) >= 62 && (P) <= 69) ? (P)-62 : (((P) == 0 || (P) == 15 || (P) == 17 || (P) == 21) ? 0 : (((P) == 1 || (P) == 14 || (P) == 16 || (P) == 20) ? 1 : (((P) == 19) ? 2 : (((P) == 5 || (P) == 6 || (P) == 18) ? 3 : (((P) == 2) ? 4 : (((P) == 3 || (P) == 4) ? 5 : 7)))))))))))))))
 
 // --- Arduino 644 ---
 #elif (defined(__AVR_ATmega644__) || \
        defined(__AVR_ATmega644P__))
 
-#define UART_RX_PIN     (8) //PD0
-#define UART_TX_PIN     (9) //PD1
+#define UART_RX_PIN (8) //PD0
+#define UART_TX_PIN (9) //PD1
 
-#define I2C_SDA_PIN     (17) //PC1
-#define I2C_SCL_PIN     (16) //PC0
+#define I2C_SDA_PIN (17) //PC1
+#define I2C_SCL_PIN (16) //PC0
 
-#define SPI_HW_SS_PIN   (4) //PB4
+#define SPI_HW_SS_PIN (4)   //PB4
 #define SPI_HW_MOSI_PIN (5) //PB5
 #define SPI_HW_MISO_PIN (6) //PB6
-#define SPI_HW_SCK_PIN  (7) //PB7
+#define SPI_HW_SCK_PIN (7)  //PB7
 
 #define __digitalPinToPortReg(P) \
-(((P) >= 0 && (P) <= 7) ? &PORTB : (((P) >= 8 && (P) <= 15) ? &PORTD : (((P) >= 16 && (P) <= 23) ? &PORTC : &PORTA)))
+    (((P) >= 0 && (P) <= 7) ? &PORTB : (((P) >= 8 && (P) <= 15) ? &PORTD : (((P) >= 16 && (P) <= 23) ? &PORTC : &PORTA)))
 #define __digitalPinToDDRReg(P) \
-(((P) >= 0 && (P) <= 7) ? &DDRB : (((P) >= 8 && (P) <= 15) ? &DDRD : (((P) >= 8 && (P) <= 15) ? &DDRC : &DDRA)))
+    (((P) >= 0 && (P) <= 7) ? &DDRB : (((P) >= 8 && (P) <= 15) ? &DDRD : (((P) >= 8 && (P) <= 15) ? &DDRC : &DDRA)))
 #define __digitalPinToPINReg(P) \
-(((P) >= 0 && (P) <= 7) ? &PINB : (((P) >= 8 && (P) <= 15) ? &PIND : (((P) >= 8 && (P) <= 15) ? &PINC : &PINA)))
+    (((P) >= 0 && (P) <= 7) ? &PINB : (((P) >= 8 && (P) <= 15) ? &PIND : (((P) >= 8 && (P) <= 15) ? &PINC : &PINA)))
 #define __digitalPinToBit(P) \
-(((P) >= 0 && (P) <= 7) ? (P) : (((P) >= 8 && (P) <= 15) ? (P) - 8 : (((P) >= 16 && (P) <= 23) ? (P) - 16 : (P) - 24)))
-
+    (((P) >= 0 && (P) <= 7) ? (P) : (((P) >= 8 && (P) <= 15) ? (P)-8 : (((P) >= 16 && (P) <= 23) ? (P)-16 : (P)-24)))
 
 // --- Arduino Leonardo and ATmega16U4/32U4 based boards ---
 #elif (defined(ARDUINO_AVR_LEONARDO) || \
-       defined(__AVR_ATmega16U4__) || \
+       defined(__AVR_ATmega16U4__) ||   \
        defined(__AVR_ATmega32U4__))
 
-#define UART_RX_PIN     (0) //PD2
-#define UART_TX_PIN     (1) //PD3
+#define UART_RX_PIN (0) //PD2
+#define UART_TX_PIN (1) //PD3
 
-#define I2C_SDA_PIN     (2) //PD1
-#define I2C_SCL_PIN     (3) //PD0
+#define I2C_SDA_PIN (2) //PD1
+#define I2C_SCL_PIN (3) //PD0
 
-#define SPI_HW_SS_PIN   (17) //PB0
+#define SPI_HW_SS_PIN (17)   //PB0
 #define SPI_HW_MOSI_PIN (16) //PB2
 #define SPI_HW_MISO_PIN (14) //PB3
-#define SPI_HW_SCK_PIN  (15) //PB1
+#define SPI_HW_SCK_PIN (15)  //PB1
 
 #define __digitalPinToPortReg(P) \
-((((P) >= 0 && (P) <= 4) || (P) == 6 || (P) == 12 || (P) == 24 || (P) == 25 || (P) == 29) ? &PORTD : (((P) == 5 || (P) == 13) ? &PORTC : (((P) >= 18 && (P) <= 23)) ? &PORTF : (((P) == 7) ? &PORTE : &PORTB)))
+    ((((P) >= 0 && (P) <= 4) || (P) == 6 || (P) == 12 || (P) == 24 || (P) == 25 || (P) == 29) ? &PORTD : (((P) == 5 || (P) == 13) ? &PORTC : (((P) >= 18 && (P) <= 23)) ? &PORTF : (((P) == 7) ? &PORTE : &PORTB)))
 #define __digitalPinToDDRReg(P) \
-((((P) >= 0 && (P) <= 4) || (P) == 6 || (P) == 12 || (P) == 24 || (P) == 25 || (P) == 29) ? &DDRD : (((P) == 5 || (P) == 13) ? &DDRC : (((P) >= 18 && (P) <= 23)) ? &DDRF : (((P) == 7) ? &DDRE : &DDRB)))
+    ((((P) >= 0 && (P) <= 4) || (P) == 6 || (P) == 12 || (P) == 24 || (P) == 25 || (P) == 29) ? &DDRD : (((P) == 5 || (P) == 13) ? &DDRC : (((P) >= 18 && (P) <= 23)) ? &DDRF : (((P) == 7) ? &DDRE : &DDRB)))
 #define __digitalPinToPINReg(P) \
-((((P) >= 0 && (P) <= 4) || (P) == 6 || (P) == 12 || (P) == 24 || (P) == 25 || (P) == 29) ? &PIND : (((P) == 5 || (P) == 13) ? &PINC : (((P) >= 18 && (P) <= 23)) ? &PINF : (((P) == 7) ? &PINE : &PINB)))
+    ((((P) >= 0 && (P) <= 4) || (P) == 6 || (P) == 12 || (P) == 24 || (P) == 25 || (P) == 29) ? &PIND : (((P) == 5 || (P) == 13) ? &PINC : (((P) >= 18 && (P) <= 23)) ? &PINF : (((P) == 7) ? &PINE : &PINB)))
 #define __digitalPinToBit(P) \
-(((P) >= 8 && (P) <= 11) ? (P) - 4 : (((P) >= 18 && (P) <= 21) ? 25 - (P) : (((P) == 0) ? 2 : (((P) == 1) ? 3 : (((P) == 2) ? 1 : (((P) == 3) ? 0 : (((P) == 4) ? 4 : (((P) == 6) ? 7 : (((P) == 13) ? 7 : (((P) == 14) ? 3 : (((P) == 15) ? 1 : (((P) == 16) ? 2 : (((P) == 17) ? 0 : (((P) == 22) ? 1 : (((P) == 23) ? 0 : (((P) == 24) ? 4 : (((P) == 25) ? 7 : (((P) == 26) ? 4 : (((P) == 27) ? 5 : 6 )))))))))))))))))))
-
+    (((P) >= 8 && (P) <= 11) ? (P)-4 : (((P) >= 18 && (P) <= 21) ? 25 - (P) : (((P) == 0) ? 2 : (((P) == 1) ? 3 : (((P) == 2) ? 1 : (((P) == 3) ? 0 : (((P) == 4) ? 4 : (((P) == 6) ? 7 : (((P) == 13) ? 7 : (((P) == 14) ? 3 : (((P) == 15) ? 1 : (((P) == 16) ? 2 : (((P) == 17) ? 0 : (((P) == 22) ? 1 : (((P) == 23) ? 0 : (((P) == 24) ? 4 : (((P) == 25) ? 7 : (((P) == 26) ? 4 : (((P) == 27) ? 5 : 6)))))))))))))))))))
 
 // --- Arduino Uno and ATmega168/328 based boards ---
-#elif (defined(ARDUINO_AVR_UNO) || \
+#elif (defined(ARDUINO_AVR_UNO) ||         \
        defined(ARDUINO_AVR_DUEMILANOVE) || \
-       defined(__AVR_ATmega168__) || \
-       defined(__AVR_ATmega168A__) || \
-       defined(__AVR_ATmega168PA__) || \
-       defined(__AVR_ATmega328__) || \
-       defined(__AVR_ATmega328P__) || \
+       defined(__AVR_ATmega168__) ||       \
+       defined(__AVR_ATmega168A__) ||      \
+       defined(__AVR_ATmega168PA__) ||     \
+       defined(__AVR_ATmega328__) ||       \
+       defined(__AVR_ATmega328P__) ||      \
        defined(__AVR_ATmega328PB__))
 
-#define UART_RX_PIN     (0) //PD0
-#define UART_TX_PIN     (1) //PD1
+#define UART_RX_PIN (0) //PD0
+#define UART_TX_PIN (1) //PD1
 
-#define I2C_SDA_PIN     (18) //A4
-#define I2C_SCL_PIN     (19) //A5
+#define I2C_SDA_PIN (18) //A4
+#define I2C_SCL_PIN (19) //A5
 
-#define SPI_HW_SS_PIN   (10) //PB0
+#define SPI_HW_SS_PIN (10)   //PB0
 #define SPI_HW_MOSI_PIN (11) //PB2
 #define SPI_HW_MISO_PIN (12) //PB3
-#define SPI_HW_SCK_PIN  (13) //PB1
+#define SPI_HW_SCK_PIN (13)  //PB1
 
 #if defined(__AVR_ATmega328PB__)
 #define __digitalPinToPortReg(P) \
-(((P) >= 0 && (P) <= 7) ? &PORTD : (((P) >= 8 && (P) <= 13) ? &PORTB : (((P) >= 14 && (P) <= 19) ? &PORTC : &PORTE)))
+    (((P) >= 0 && (P) <= 7) ? &PORTD : (((P) >= 8 && (P) <= 13) ? &PORTB : (((P) >= 14 && (P) <= 19) ? &PORTC : &PORTE)))
 #define __digitalPinToDDRReg(P) \
-(((P) >= 0 && (P) <= 7) ? &DDRD : (((P) >= 8 && (P) <= 13) ? &DDRB : (((P) >= 14 && (P) <= 19) ? &DDRC : &DDRE)))
+    (((P) >= 0 && (P) <= 7) ? &DDRD : (((P) >= 8 && (P) <= 13) ? &DDRB : (((P) >= 14 && (P) <= 19) ? &DDRC : &DDRE)))
 #define __digitalPinToPINReg(P) \
-(((P) >= 0 && (P) <= 7) ? &PIND : (((P) >= 8 && (P) <= 13) ? &PINB : (((P) >= 14 && (P) <= 19) ? &PINC : &PINE)))
+    (((P) >= 0 && (P) <= 7) ? &PIND : (((P) >= 8 && (P) <= 13) ? &PINB : (((P) >= 14 && (P) <= 19) ? &PINC : &PINE)))
 #define __digitalPinToBit(P) \
-(((P) >= 0 && (P) <= 7) ? (P) : (((P) >= 8 && (P) <= 13) ? (P) - 8 : (((P) >= 14 && (P) <= 19) ? (P) - 14 : (((P) >= 20 && (P) <= 21) ? (P) - 18 : (P) - 22))))
+    (((P) >= 0 && (P) <= 7) ? (P) : (((P) >= 8 && (P) <= 13) ? (P)-8 : (((P) >= 14 && (P) <= 19) ? (P)-14 : (((P) >= 20 && (P) <= 21) ? (P)-18 : (P)-22))))
 #else
 #define __digitalPinToPortReg(P) \
-(((P) >= 0 && (P) <= 7) ? &PORTD : (((P) >= 8 && (P) <= 13) ? &PORTB : &PORTC))
+    (((P) >= 0 && (P) <= 7) ? &PORTD : (((P) >= 8 && (P) <= 13) ? &PORTB : &PORTC))
 #define __digitalPinToDDRReg(P) \
-(((P) >= 0 && (P) <= 7) ? &DDRD : (((P) >= 8 && (P) <= 13) ? &DDRB : &DDRC))
+    (((P) >= 0 && (P) <= 7) ? &DDRD : (((P) >= 8 && (P) <= 13) ? &DDRB : &DDRC))
 #define __digitalPinToPINReg(P) \
-(((P) >= 0 && (P) <= 7) ? &PIND : (((P) >= 8 && (P) <= 13) ? &PINB : &PINC))
+    (((P) >= 0 && (P) <= 7) ? &PIND : (((P) >= 8 && (P) <= 13) ? &PINB : &PINC))
 #define __digitalPinToBit(P) \
-(((P) >= 0 && (P) <= 7) ? (P) : (((P) >= 8 && (P) <= 13) ? (P) - 8 : (P) - 14))
+    (((P) >= 0 && (P) <= 7) ? (P) : (((P) >= 8 && (P) <= 13) ? (P)-8 : (P)-14))
 #endif
 
 // --- ATtinyX5 ---
 #elif defined(__AVR_ATtiny25__) || defined(__AVR_ATtiny45__) || defined(__AVR_ATtiny85__)
 // we have only PORTB
 #define __digitalPinToPortReg(P) (&PORTB)
-#define __digitalPinToDDRReg(P)  (&DDRB)
-#define __digitalPinToPINReg(P)  (&PINB)
+#define __digitalPinToDDRReg(P) (&DDRB)
+#define __digitalPinToPINReg(P) (&PINB)
 #define __digitalPinToBit(P) \
-(((P) >= 0 && (P) <= 7) ? (P) : (((P) >= 8 && (P) <= 13) ? (P) - 8 : (P) - 14))
+    (((P) >= 0 && (P) <= 7) ? (P) : (((P) >= 8 && (P) <= 13) ? (P)-8 : (P)-14))
 
 // --- ATtinyX4 + ATtinyX7 ---
 //  ATtinyX4: PORTA for 0 to 7, PORTB for 8 to 11
 //  ATtinyX7: PORTA for 0 to 7, PORTB for 8 to 15
-#elif  defined(__AVR_ATtiny24__) || defined(__AVR_ATtiny44__) || defined(__AVR_ATtiny84__) || defined(__AVR_ATtiny87__) || defined(__AVR_ATtiny167__)
+#elif defined(__AVR_ATtiny24__) || defined(__AVR_ATtiny44__) || defined(__AVR_ATtiny84__) || defined(__AVR_ATtiny87__) || defined(__AVR_ATtiny167__)
 #define __digitalPinToPortReg(P) (((P) >= 0 && (P) <= 7) ? &PORTA : &PORTB)
-#define __digitalPinToDDRReg(P)  (((P) >= 0 && (P) <= 7) ? &DDRA : &DDRB)
-#define __digitalPinToPINReg(P)  (((P) >= 0 && (P) <= 7) ? &PINA : &PINB)
-#define __digitalPinToBit(P)     (((P) >= 0 && (P) <= 7) ? (P) : (P) - 8 )
+#define __digitalPinToDDRReg(P) (((P) >= 0 && (P) <= 7) ? &DDRA : &DDRB)
+#define __digitalPinToPINReg(P) (((P) >= 0 && (P) <= 7) ? &PINA : &PINB)
+#define __digitalPinToBit(P) (((P) >= 0 && (P) <= 7) ? (P) : (P)-8)
 
 // --- Other ---
 #else
 
-#define I2C_SDA_PIN     SDA
-#define I2C_SCL_PIN     SCL
+#define I2C_SDA_PIN SDA
+#define I2C_SCL_PIN SCL
 
-#define SPI_HW_SS_PIN   SS
+#define SPI_HW_SS_PIN SS
 #define SPI_HW_MOSI_PIN MOSI
 #define SPI_HW_MISO_PIN MISO
-#define SPI_HW_SCK_PIN  SCK
-
+#define SPI_HW_SCK_PIN SCK
 
 #endif
 //#endif  //#ifndef digitalPinToPortReg
 
-
 #ifndef digitalWriteFast
 #if (defined(__AVR__) || defined(ARDUINO_ARCH_AVR))
-#define digitalWriteFast(P, V) \
-if (__builtin_constant_p(P) && __builtin_constant_p(V)) { \
-  BIT_WRITE(*__digitalPinToPortReg(P), __digitalPinToBit(P), (V)); \
-} else { \
-  digitalWrite((P), (V)); \
-}
+#define digitalWriteFast(P, V)                                           \
+    if (__builtin_constant_p(P) && __builtin_constant_p(V))              \
+    {                                                                    \
+        BIT_WRITE(*__digitalPinToPortReg(P), __digitalPinToBit(P), (V)); \
+    }                                                                    \
+    else                                                                 \
+    {                                                                    \
+        digitalWrite((P), (V));                                          \
+    }
 #else
 #define digitalWriteFast digitalWrite
 #endif
 #endif
 
-
 #ifndef pinModeFast
 #if (defined(__AVR__) || defined(ARDUINO_ARCH_AVR))
-#define pinModeFast(P, V) \
-if (__builtin_constant_p(P) && __builtin_constant_p(V)) { \
-  if (V == INPUT_PULLUP) {\
-    BIT_WRITE(*__digitalPinToDDRReg(P), __digitalPinToBit(P), (INPUT)); \
-    BIT_WRITE(*__digitalPinToPortReg(P), __digitalPinToBit(P), (HIGH)); \
-  } else { \
-    BIT_WRITE(*__digitalPinToDDRReg(P), __digitalPinToBit(P), (V)); \
-  } \
-} else { \
-  pinMode((P), (V)); \
-}
+#define pinModeFast(P, V)                                                       \
+    if (__builtin_constant_p(P) && __builtin_constant_p(V))                     \
+    {                                                                           \
+        if (V == INPUT_PULLUP)                                                  \
+        {                                                                       \
+            BIT_WRITE(*__digitalPinToDDRReg(P), __digitalPinToBit(P), (INPUT)); \
+            BIT_WRITE(*__digitalPinToPortReg(P), __digitalPinToBit(P), (HIGH)); \
+        }                                                                       \
+        else                                                                    \
+        {                                                                       \
+            BIT_WRITE(*__digitalPinToDDRReg(P), __digitalPinToBit(P), (V));     \
+        }                                                                       \
+    }                                                                           \
+    else                                                                        \
+    {                                                                           \
+        pinMode((P), (V));                                                      \
+    }
 #else
 #define pinModeFast pinMode
 #endif
 #endif
 
-
 #ifndef digitalReadFast
 #if (defined(__AVR__) || defined(ARDUINO_ARCH_AVR))
-#define digitalReadFast(P) ( (int) __digitalReadFast((P)) )
-#define __digitalReadFast(P ) \
-  (__builtin_constant_p(P) ) ? ( \
-  ( BIT_READ(*__digitalPinToPINReg(P), __digitalPinToBit(P))) ? HIGH:LOW ) : \
-  digitalRead((P))
+#define digitalReadFast(P) ((int)__digitalReadFast((P)))
+#define __digitalReadFast(P)                                                                                 \
+    (__builtin_constant_p(P)) ? (                                                                            \
+                                    (BIT_READ(*__digitalPinToPINReg(P), __digitalPinToBit(P))) ? HIGH : LOW) \
+                              : digitalRead((P))
 #else
 #define digitalReadFast digitalRead
 #endif
 #endif
-
 
 #ifndef digitalToggleFast
 #if (defined(__AVR__) || defined(ARDUINO_ARCH_AVR))
 #define digitalToggleFast(P) BIT_SET(*__digitalPinToPINReg(P), __digitalPinToBit(P))
 #endif
 #endif
-
 
 #endif //__digitalWriteFast_h_

--- a/distance-moved.cpp
+++ b/distance-moved.cpp
@@ -1,5 +1,5 @@
 /*
- * distance-moved - provides encoder interrupts to measure distance moved 
+ * distance-moved - provides encoder interrupts to measure distance moved
  * usually by encoders on the motor shafts.
 
    ukmarsey is a machine and human command-based Robot Low-level I/O platform initially targetting UKMARSBot
@@ -8,7 +8,7 @@
        https://ukmars.org/
        https://github.com/ukmars/ukmarsbot
        https://github.com/robzed/pizero_for_ukmarsbot
-       
+
   MIT License
 
   Copyright (c) 2020-2021 Rob Probin & Peter Harrison
@@ -33,12 +33,11 @@
   SOFTWARE.
 */
 
-#include <Arduino.h>
 #include "digitalWriteFast.h"
 #include "hardware_pins.h"
 #include "public.h"
 #include "robot_config.h"
-
+#include <Arduino.h>
 
 /***
  * Global variables
@@ -48,79 +47,80 @@ volatile int32_t encoderRightCount;
 int32_t encoderSum;
 int32_t encoderDifference;
 
-
-void setupEncoders() {
-  // left
-  pinMode(ENCODER_LEFT_CLK, INPUT);
-  pinMode(ENCODER_LEFT_B, INPUT);
-  // configure the pin change
-  bitClear(EICRA, ISC01);
-  bitSet(EICRA, ISC00);
-  // enable the interrupt
-  bitSet(EIMSK, INT0);
-  encoderLeftCount = 0;
-  // right
-  pinMode(ENCODER_RIGHT_CLK, INPUT);
-  pinMode(ENCODER_RIGHT_B, INPUT);
-  // configure the pin change
-  bitClear(EICRA, ISC11);
-  bitSet(EICRA, ISC10);
-  // enable the interrupt
-  bitSet(EIMSK, INT1);
-  encoderRightCount = 0;
+void setupEncoders()
+{
+    // left
+    pinMode(ENCODER_LEFT_CLK, INPUT);
+    pinMode(ENCODER_LEFT_B, INPUT);
+    // configure the pin change
+    bitClear(EICRA, ISC01);
+    bitSet(EICRA, ISC00);
+    // enable the interrupt
+    bitSet(EIMSK, INT0);
+    encoderLeftCount = 0;
+    // right
+    pinMode(ENCODER_RIGHT_CLK, INPUT);
+    pinMode(ENCODER_RIGHT_B, INPUT);
+    // configure the pin change
+    bitClear(EICRA, ISC11);
+    bitSet(EICRA, ISC10);
+    // enable the interrupt
+    bitSet(EIMSK, INT1);
+    encoderRightCount = 0;
 }
 
-ISR(INT0_vect) {
-  static bool oldA = 0;
-  static bool oldB = 0;
-  bool newB = digitalReadFast(ENCODER_LEFT_B);
-  bool newA = digitalReadFast(ENCODER_LEFT_CLK) ^ newB;
-  int delta = ENCODER_LEFT_POLARITY * ((oldA ^ newB) - (newA ^ oldB));
-  encoderLeftCount += delta;
-  oldA = newA;
-  oldB = newB;
+ISR(INT0_vect)
+{
+    static bool oldA = 0;
+    static bool oldB = 0;
+    bool newB = digitalReadFast(ENCODER_LEFT_B);
+    bool newA = digitalReadFast(ENCODER_LEFT_CLK) ^ newB;
+    int delta = ENCODER_LEFT_POLARITY * ((oldA ^ newB) - (newA ^ oldB));
+    encoderLeftCount += delta;
+    oldA = newA;
+    oldB = newB;
 }
 
-ISR(INT1_vect) {
-  static bool oldA = 0;
-  static bool oldB = 0;
-  bool newB = digitalReadFast(ENCODER_RIGHT_B);
-  bool newA = digitalReadFast(ENCODER_RIGHT_CLK) ^ newB;
-  int delta = ENCODER_RIGHT_POLARITY * ((oldA ^ newB) - (newA ^ oldB));
-  encoderRightCount += delta;
-  oldA = newA;
-  oldB = newB;
+ISR(INT1_vect)
+{
+    static bool oldA = 0;
+    static bool oldB = 0;
+    bool newB = digitalReadFast(ENCODER_RIGHT_B);
+    bool newA = digitalReadFast(ENCODER_RIGHT_CLK) ^ newB;
+    int delta = ENCODER_RIGHT_POLARITY * ((oldA ^ newB) - (newA ^ oldB));
+    encoderRightCount += delta;
+    oldA = newA;
+    oldB = newB;
 }
 
+void print_encoder_setup()
+{
 
-void print_encoder_setup() {
+    Serial.print(F("MM PER COUNT = "));
+    Serial.println(MM_PER_COUNT, 5);
 
-  Serial.print(F("MM PER COUNT = "));
-  Serial.println(MM_PER_COUNT, 5);
+    Serial.print(F("So 500mm travel would be 500/"));
+    Serial.print(MM_PER_COUNT, 5);
+    Serial.print(F(" = "));
+    Serial.print(500.0 / MM_PER_COUNT);
+    Serial.println(F(" counts"));
+    Serial.println();
 
-  Serial.print(F("So 500mm travel would be 500/"));
-  Serial.print(MM_PER_COUNT, 5);
-  Serial.print(F(" = "));
-  Serial.print(500.0/MM_PER_COUNT);
-  Serial.println(F(" counts"));
-  Serial.println();
+    Serial.print(F("DEG PER COUNT = "));
+    Serial.println(DEG_PER_COUNT, 5);
 
-  Serial.print(F("DEG PER COUNT = "));
-  Serial.println(DEG_PER_COUNT, 5);
-
-  Serial.print(F("So 360 degrees rotation would be 360/"));
-  Serial.print(DEG_PER_COUNT, 5);
-  Serial.print(F(" = "));
-  Serial.print(360.0/DEG_PER_COUNT);
-  Serial.println(F(" counts"));
-  Serial.println();
+    Serial.print(F("So 360 degrees rotation would be 360/"));
+    Serial.print(DEG_PER_COUNT, 5);
+    Serial.print(F(" = "));
+    Serial.print(360.0 / DEG_PER_COUNT);
+    Serial.println(F(" counts"));
+    Serial.println();
 }
-
 
 void zero_encoders()
 {
-  encoderLeftCount = 0;
-  encoderRightCount = 0;
+    encoderLeftCount = 0;
+    encoderRightCount = 0;
 }
 
 void print_encoders()

--- a/hardware_pins.h
+++ b/hardware_pins.h
@@ -25,4 +25,3 @@ const int FUNCTION_PIN = A6;
 const int BATTERY_VOLTS = A7;
 /****/
 #endif
-

--- a/interpreter.cpp
+++ b/interpreter.cpp
@@ -33,9 +33,9 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
   SOFTWARE.
 */
-#include <Arduino.h>
 #include "digitalWriteFast.h"
 #include "public.h"
+#include <Arduino.h>
 #include <EEPROM.h>
 
 /*
@@ -43,10 +43,9 @@
  */
 
 #define MAX_INPUT_SIZE 14
-static char inputString[MAX_INPUT_SIZE];         // a String to hold incoming data
-static int inputIndex = 0;  // where we are on the input
+static char inputString[MAX_INPUT_SIZE]; // a String to hold incoming data
+static int inputIndex = 0;               // where we are on the input
 static bool interpreter_echo = true;
-
 
 //
 // There are (NUM_STORED_PARAMS+2) * 4 bytes stored in EEPROM. NOTE: The last one is a magic number to detect an uninitialised EEPROM.
@@ -56,75 +55,75 @@ static bool interpreter_echo = true;
 float stored_params[NUM_STORED_PARAMS];
 static const float stored_parameters_default_values[NUM_STORED_PARAMS] = {
 
-        // Index: Usage
-  0.0F, //  0: undefined
-  0.0F, //  1: undefined
-  0.0F, //  2: undefined
-  0.0F, //  3: undefined
+    // Index: Usage
+    0.0F, //  0: undefined
+    0.0F, //  1: undefined
+    0.0F, //  2: undefined
+    0.0F, //  3: undefined
 
-  0.0F, //  4: undefined
-  0.0F, //  5: undefined
-  0.0F, //  6: undefined
-  0.0F, //  7: undefined
+    0.0F, //  4: undefined
+    0.0F, //  5: undefined
+    0.0F, //  6: undefined
+    0.0F, //  7: undefined
 
-  0.0F, //  8: undefined
-  0.0F, //  9: undefined
-  0.0F, // 10: undefined
-  0.0F, // 11: undefined
+    0.0F, //  8: undefined
+    0.0F, //  9: undefined
+    0.0F, // 10: undefined
+    0.0F, // 11: undefined
 
-  0.0F, // 12: undefined
-  0.0F, // 13: undefined
-  0.0F, // 14: undefined
-  0.0F, // 15: undefined
+    0.0F, // 12: undefined
+    0.0F, // 13: undefined
+    0.0F, // 14: undefined
+    0.0F, // 15: undefined
 
 };
 
 #define NUMBER_OF_BITFIELD_STORED_PARAMS 32
 static const uint32_t bitfield_default_values =
-// Default 0UL/1UL  Index: Usage
-  (0UL << 31) +  // 131: undefined
-  (0UL << 30) +  // 130: undefined
-  (0UL << 29) +  // 129: undefined
-  (0UL << 28) +  // 128: undefined
-  (0UL << 27) +  // 127: undefined
-  (0UL << 26) +  // 126: undefined
-  (0UL << 25) +  // 125: undefined
-  (0UL << 24) +  // 124: undefined
+    // Default 0UL/1UL  Index: Usage
+    (0UL << 31) + // 131: undefined
+    (0UL << 30) + // 130: undefined
+    (0UL << 29) + // 129: undefined
+    (0UL << 28) + // 128: undefined
+    (0UL << 27) + // 127: undefined
+    (0UL << 26) + // 126: undefined
+    (0UL << 25) + // 125: undefined
+    (0UL << 24) + // 124: undefined
 
-  (0UL << 23) +  // 123: undefined
-  (0UL << 22) +  // 122: undefined
-  (0UL << 21) +  // 121: undefined
-  (0UL << 20) +  // 120: undefined
-  (0UL << 19) +  // 119: undefined
-  (0UL << 18) +  // 118: undefined
-  (0UL << 17) +  // 117: undefined
-  (0UL << 16) +  // 116: undefined
+    (0UL << 23) + // 123: undefined
+    (0UL << 22) + // 122: undefined
+    (0UL << 21) + // 121: undefined
+    (0UL << 20) + // 120: undefined
+    (0UL << 19) + // 119: undefined
+    (0UL << 18) + // 118: undefined
+    (0UL << 17) + // 117: undefined
+    (0UL << 16) + // 116: undefined
 
-  (0UL << 15) +  // 115: undefined
-  (0UL << 14) +  // 114: undefined
-  (0UL << 13) +  // 113: undefined
-  (0UL << 12) +  // 112: undefined
-  (0UL << 11) +  // 111: undefined
-  (0UL << 10) +  // 110: undefined
-  (0UL <<  9) +  // 109: undefined
-  (0UL <<  8) +  // 108: undefined
+    (0UL << 15) + // 115: undefined
+    (0UL << 14) + // 114: undefined
+    (0UL << 13) + // 113: undefined
+    (0UL << 12) + // 112: undefined
+    (0UL << 11) + // 111: undefined
+    (0UL << 10) + // 110: undefined
+    (0UL << 9) +  // 109: undefined
+    (0UL << 8) +  // 108: undefined
 
-  (0UL <<  7) +  // 107: undefined
-  (0UL <<  6) +  // 106: undefined
-  (0UL <<  5) +  // 105: undefined
-  (0UL <<  4) +  // 104: undefined
-  (0UL <<  3) +  // 103: undefined
-  (0UL <<  2) +  // 102: undefined
-  (0UL <<  1) +  // 101: undefined
-  (0UL      ) ;  // 100: undefined
+    (0UL << 7) + // 107: undefined
+    (0UL << 6) + // 106: undefined
+    (0UL << 5) + // 105: undefined
+    (0UL << 4) + // 104: undefined
+    (0UL << 3) + // 103: undefined
+    (0UL << 2) + // 102: undefined
+    (0UL << 1) + // 101: undefined
+    (0UL);       // 100: undefined
 //
 // actual data storage
 //
 uint32_t bitfield_stored_params = bitfield_default_values;
 
 // Addresses
-#define BITFIELD_ADDRESS ((NUM_STORED_PARAMS+1)*4)
-#define MAGIC_ADDRESS (BITFIELD_ADDRESS+sizeof(bitfield_stored_params))
+#define BITFIELD_ADDRESS ((NUM_STORED_PARAMS + 1) * 4)
+#define MAGIC_ADDRESS (BITFIELD_ADDRESS + sizeof(bitfield_stored_params))
 
 //
 // Version number for parameter configuration in EEPROM
@@ -136,15 +135,17 @@ uint32_t bitfield_stored_params = bitfield_default_values;
 // Magic to detect uninitialised space
 #define MAGIC_NUMBER ((0x00CAFE00) ^ (PARAMETER_EEPROM_VERSION))
 
-
 /** @brief  Access a stored parameter
  *  @param  Index of parameter
  *  @return stored_param, or 0 if that parameter doesn't exist.
  */
 float get_float_param(int param_index)
 {
-  if(param_index < 0 or param_index > NUM_STORED_PARAMS) { return 0; }
-  return stored_params[param_index];
+    if (param_index < 0 or param_index > NUM_STORED_PARAMS)
+    {
+        return 0;
+    }
+    return stored_params[param_index];
 }
 
 /** @brief  Access a stored bool parameter
@@ -153,19 +154,22 @@ float get_float_param(int param_index)
  */
 bool get_bool_param(int param_index)
 {
-  if(param_index < 100 or param_index > NUMBER_OF_BITFIELD_STORED_PARAMS) { return false; }
-  return bitfield_stored_params & (1<<(param_index-100));
+    if (param_index < 100 or param_index > NUMBER_OF_BITFIELD_STORED_PARAMS)
+    {
+        return false;
+    }
+    return bitfield_stored_params & (1 << (param_index - 100));
 }
 
 // ------------------------------------------
 enum
 {
-  T_OK = 0,
-  T_OUT_OF_RANGE = 1,
-  T_READ_NOT_SUPPORTED = 2,
-  T_LINE_TOO_LONG = 3,
-  T_UNKNOWN_COMMAND = 4,
-  T_UNEXPECTED_TOKEN = 5
+    T_OK = 0,
+    T_OUT_OF_RANGE = 1,
+    T_READ_NOT_SUPPORTED = 2,
+    T_LINE_TOO_LONG = 3,
+    T_UNKNOWN_COMMAND = 4,
+    T_UNEXPECTED_TOKEN = 5
 };
 bool verbose_errors = true;
 
@@ -173,54 +177,56 @@ bool verbose_errors = true;
  *  @param  error to be printed
  *  @return void
  */
-void interpreter_error(int error, char* extra=0)
+void interpreter_error(int error, char *extra = 0)
 {
-  if(verbose_errors)
-  {
-    if (error != T_OK)
+    if (verbose_errors)
     {
-      Serial.print("@Error:");
-    }
-    switch(error)
-    {
-      case T_OK:
-        Serial.println(F("OK"));
-        break;
-      case T_OUT_OF_RANGE:
-        Serial.println(F("Out of range"));
-        break;
-      case T_READ_NOT_SUPPORTED:
-        Serial.println(F("Read not supported"));
-        break;
-      case T_LINE_TOO_LONG:
-        Serial.println(F("Too long"));
-        break;
-      case T_UNKNOWN_COMMAND:
-        Serial.print(F("Unknown "));
-        if(extra) {
-          Serial.println(extra);
-        }
-        else
+        if (error != T_OK)
         {
-          Serial.println();
+            Serial.print("@Error:");
         }
-        break;
-      case T_UNEXPECTED_TOKEN:
-        Serial.println(F("Unexpected"));
-        break;
-      default:
-        Serial.println(F("Error"));
-        break;
+        switch (error)
+        {
+        case T_OK:
+            Serial.println(F("OK"));
+            break;
+        case T_OUT_OF_RANGE:
+            Serial.println(F("Out of range"));
+            break;
+        case T_READ_NOT_SUPPORTED:
+            Serial.println(F("Read not supported"));
+            break;
+        case T_LINE_TOO_LONG:
+            Serial.println(F("Too long"));
+            break;
+        case T_UNKNOWN_COMMAND:
+            Serial.print(F("Unknown "));
+            if (extra)
+            {
+                Serial.println(extra);
+            }
+            else
+            {
+                Serial.println();
+            }
+            break;
+        case T_UNEXPECTED_TOKEN:
+            Serial.println(F("Unexpected"));
+            break;
+        default:
+            Serial.println(F("Error"));
+            break;
+        }
     }
-  }
-  else
-  {
-    Serial.print("@Error:");
-    Serial.println(error);
-  }
+    else
+    {
+        Serial.print("@Error:");
+        Serial.println(error);
+    }
 }
 
-typedef struct {
+typedef struct
+{
     const char *nam;
     void (*func)();
 } entry_t;
@@ -233,7 +239,7 @@ typedef struct {
  *  @param
  *  @return void
  */
-void led() { digitalWriteFast(LED_BUILTIN, (inputString[1] == '0') ? LOW:HIGH); }
+void led() { digitalWriteFast(LED_BUILTIN, (inputString[1] == '0') ? LOW : HIGH); }
 
 /** @brief  Prints OK
  *  @param
@@ -241,32 +247,31 @@ void led() { digitalWriteFast(LED_BUILTIN, (inputString[1] == '0') ? LOW:HIGH); 
  */
 void ok() { interpreter_error(T_OK); }
 
-
 /** @brief  Reset the robot state to a known value
  *          NOTE: Does not reset $ parameters.
  *  @param
  *  @return void
  */
-void reset_state() {
-  char function = inputString[1];
-  if(function == '^')
-  {
-    void(* resetFunc) (void) = 0;  // declare reset fuction at address 0
-    resetFunc();
-  }
-  else if(function == '?')
-  {
-      extern uint8_t PoR_status;
-      Serial.println(PoR_status);
-  }
-  else
-  {
-    // We should reset all state here. At the moment there isn't any.
-    Serial.println(F("RST"));
-    // Reset the actual state
-  }
+void reset_state()
+{
+    char function = inputString[1];
+    if (function == '^')
+    {
+        void (*resetFunc)(void) = 0; // declare reset fuction at address 0
+        resetFunc();
+    }
+    else if (function == '?')
+    {
+        extern uint8_t PoR_status;
+        Serial.println(PoR_status);
+    }
+    else
+    {
+        // We should reset all state here. At the moment there isn't any.
+        Serial.println(F("RST"));
+        // Reset the actual state
+    }
 }
-
 
 /** @brief  Show version of the program.
  *  @param
@@ -274,102 +279,102 @@ void reset_state() {
  */
 void show_version() { Serial.println(F("v1.3")); }
 
-
 /** @brief  Print the decoded switch value.
  *  @param
  *  @return void
  */
 void print_switches() { Serial.println(readFunctionSwitch()); }
 
-
 /** @brief  Select one of several hardware motor tests.
  *  @param
  *  @return void
  */
-void motor_test() {
+void motor_test()
+{
 
-  char function = inputString[1];
+    char function = inputString[1];
 
-  switch (function) {
+    switch (function)
+    {
     case '0':
-      setMotorVolts(0, 0);
-      Serial.println(F("motors off"));
-      break;
+        setMotorVolts(0, 0);
+        Serial.println(F("motors off"));
+        break;
     case '1':
-      setMotorVolts(1.5, 1.5);
-      Serial.println(F("forward 25%"));
-      break;
+        setMotorVolts(1.5, 1.5);
+        Serial.println(F("forward 25%"));
+        break;
     case '2':
-      setMotorVolts(3.0, 3.0);
-      Serial.println(F("forward 50%"));
-      break;
+        setMotorVolts(3.0, 3.0);
+        Serial.println(F("forward 50%"));
+        break;
     case '3':
-      setMotorVolts(4.5, 4.5);
-      Serial.println(F("forward 75%"));
-      break;
+        setMotorVolts(4.5, 4.5);
+        Serial.println(F("forward 75%"));
+        break;
     case '4':
-      setMotorVolts(-1.5, -1.5);
-      Serial.println(F("reverse 25%"));
-      break;
+        setMotorVolts(-1.5, -1.5);
+        Serial.println(F("reverse 25%"));
+        break;
     case '5':
-      setMotorVolts(-3.0, -3.0);
-      Serial.println(F("reverse 50%"));
-      break;
+        setMotorVolts(-3.0, -3.0);
+        Serial.println(F("reverse 50%"));
+        break;
     case '6':
-      setMotorVolts(-4.5, -4.5);
-      Serial.println(F("reverse 75%"));
-      break;
+        setMotorVolts(-4.5, -4.5);
+        Serial.println(F("reverse 75%"));
+        break;
     case '7':
-      setMotorVolts(-1.5, 1.5);
-      Serial.println(F("spin left 25%"));
-      break;
+        setMotorVolts(-1.5, 1.5);
+        Serial.println(F("spin left 25%"));
+        break;
     case '8':
-      setMotorVolts(-3.0, 3.0);
-      Serial.println(F("spin left 50%"));
-      break;
+        setMotorVolts(-3.0, 3.0);
+        Serial.println(F("spin left 50%"));
+        break;
     case '9':
-      setMotorVolts(1.5, -1.5);
-      Serial.println(F("spin right 25%"));
-      break;
+        setMotorVolts(1.5, -1.5);
+        Serial.println(F("spin right 25%"));
+        break;
     case 'a':
-      setMotorVolts(3.0, -3.0);
-      Serial.println(F("spin right 50%"));
-      break;
+        setMotorVolts(3.0, -3.0);
+        Serial.println(F("spin right 50%"));
+        break;
     case 'b':
-      setMotorVolts(0, 1.5);
-      Serial.println(F("pivot left 25%"));
-      break;
+        setMotorVolts(0, 1.5);
+        Serial.println(F("pivot left 25%"));
+        break;
     case 'c':
-      setMotorVolts(1.5, 0);
-      Serial.println(F("pivot right 25%"));
-      break;
+        setMotorVolts(1.5, 0);
+        Serial.println(F("pivot right 25%"));
+        break;
     case 'd':
-      setMotorVolts(1.5, 3.0);
-      Serial.println(F("curve left"));
-      break;
+        setMotorVolts(1.5, 3.0);
+        Serial.println(F("curve left"));
+        break;
     case 'e':
-      setMotorVolts(3.0, 1.5);
-      Serial.println(F("curve right"));
-      break;
+        setMotorVolts(3.0, 1.5);
+        Serial.println(F("curve right"));
+        break;
     case 'f':
-      setMotorVolts(4.5, 3.0);
-      Serial.println(F("big curve right"));
-      break;
+        setMotorVolts(4.5, 3.0);
+        Serial.println(F("big curve right"));
+        break;
     default:
-      setMotorVolts(0, 0);
-      break;
-  }
-
-  uint32_t endTime = millis() + 2000;
-  while (endTime > millis()) {
-    if (readFunctionSwitch() == 16) {
-      break;  // stop running if the button is pressed
+        setMotorVolts(0, 0);
+        break;
     }
-  }
-  // be sure to turn off the motors
-  setMotorVolts(0, 0);
 
-
+    uint32_t endTime = millis() + 2000;
+    while (endTime > millis())
+    {
+        if (readFunctionSwitch() == 16)
+        {
+            break; // stop running if the button is pressed
+        }
+    }
+    // be sure to turn off the motors
+    setMotorVolts(0, 0);
 }
 
 //int numeric_mode = 10;
@@ -384,24 +389,24 @@ void motor_test() {
 // -1 means invalid value
 int decode_input_value(int index)
 {
-  int n = inputString[index++]-'0';
-  if(n < 0 or n >= 10)
-  {
-    inputIndex = index-1;
-    return -1;
-  }
-  while(true)
-  {
-    int n2 = inputString[index]-'0';
-    if(n2 < 0 or n2 >= 10)
+    int n = inputString[index++] - '0';
+    if (n < 0 or n >= 10)
     {
-      break;
+        inputIndex = index - 1;
+        return -1;
     }
-    n = n*10 + n2;
-    index++;
-  }
-  inputIndex = index;
-  return n;
+    while (true)
+    {
+        int n2 = inputString[index] - '0';
+        if (n2 < 0 or n2 >= 10)
+        {
+            break;
+        }
+        n = n * 10 + n2;
+        index++;
+    }
+    inputIndex = index;
+    return n;
 }
 
 /** @brief  Decodes a signed int from the input line
@@ -411,26 +416,25 @@ int decode_input_value(int index)
  */
 int decode_input_value_signed(int index)
 {
-  if(inputString[index]=='-')
-  {
-    int value = decode_input_value(index+1);
-    if(value < 0)
+    if (inputString[index] == '-')
     {
-      return 0;
+        int value = decode_input_value(index + 1);
+        if (value < 0)
+        {
+            return 0;
+        }
+        return -value;
     }
-    return -value;
-  }
-  else
-  {
-    int value = decode_input_value(index);
-    if(value < 0)
+    else
     {
-      return 0;
+        int value = decode_input_value(index);
+        if (value < 0)
+        {
+            return 0;
+        }
+        return value;
     }
-    return value;
-  }
 }
-
 
 /** @brief  Decodes a fraction float (past decimal point) from the input line
  *  @param  index of where in the input should be parsed
@@ -440,20 +444,20 @@ int decode_input_value_signed(int index)
  */
 float fractional_float(int index, float n)
 {
-  float frac = 0.1F;
-  while(true)
-  {
-    int digit = inputString[index]-'0';
-    if(digit < 0 or digit > 9)
+    float frac = 0.1F;
+    while (true)
     {
-      break;
+        int digit = inputString[index] - '0';
+        if (digit < 0 or digit > 9)
+        {
+            break;
+        }
+        n += digit * frac;
+        frac *= 0.1F;
+        index++;
     }
-    n += digit * frac;
-    frac *= 0.1F;
-    index++;
-  }
-  inputIndex = index;
-  return n;
+    inputIndex = index;
+    return n;
 }
 
 /** @brief  Decodes a float from the input line
@@ -465,24 +469,24 @@ float fractional_float(int index, float n)
 // Differnt to atoi, etc., because updates index.
 float decode_input_value_float_unsigned(int index)
 {
-  float n = 0.0F;
-  while(true)
-  {
-    int digit = inputString[index];
-    if(digit < '0' or digit > '9')
+    float n = 0.0F;
+    while (true)
     {
-      if(digit == '.') // decimal point
-      {
+        int digit = inputString[index];
+        if (digit < '0' or digit > '9')
+        {
+            if (digit == '.') // decimal point
+            {
+                index++;
+                return fractional_float(index, n);
+            }
+            break;
+        }
+        n = n * 10 + digit - '0';
         index++;
-        return fractional_float(index, n);
-      }
-      break;
     }
-    n = n*10 + digit-'0';
-    index++;
-  }
-  inputIndex = index;
-  return n;
+    inputIndex = index;
+    return n;
 }
 
 /** @brief  Parses a float from the input line
@@ -492,19 +496,19 @@ float decode_input_value_float_unsigned(int index)
  */
 float decode_input_value_float(int index)
 {
-  if(inputString[index]=='-')
-  {
-    float value = decode_input_value_float_unsigned(index+1);
-    if(value>0)
+    if (inputString[index] == '-')
     {
-      return -value;
+        float value = decode_input_value_float_unsigned(index + 1);
+        if (value > 0)
+        {
+            return -value;
+        }
+        return -1;
     }
-    return -1;
-  }
-  else
-  {
-    return decode_input_value_float_unsigned(index);
-  }
+    else
+    {
+        return decode_input_value_float_unsigned(index);
+    }
 }
 
 /** @brief Reads or writes a digital GPIO
@@ -512,91 +516,90 @@ float decode_input_value_float(int index)
  */
 void digital_pin_control()
 {
-  // D3=1
-  // D13=0
-  // Ignore spaces?
+    // D3=1
+    // D13=0
+    // Ignore spaces?
 
-  int port = decode_input_value(1);
-  if(port >= 0)
-  {
-    if(inputString[inputIndex] == '=')
+    int port = decode_input_value(1);
+    if (port >= 0)
     {
-      // write port
-      //
-      // Could be: digitWrite(port, inputString[inputIndex+1]-'0')
-      if(inputString[inputIndex+1] == '1')
-      {
-        digitalWriteFast(port, HIGH);
-      }
-      else
-      {
-        digitalWriteFast(port, LOW);
-      }
+        if (inputString[inputIndex] == '=')
+        {
+            // write port
+            //
+            // Could be: digitWrite(port, inputString[inputIndex+1]-'0')
+            if (inputString[inputIndex + 1] == '1')
+            {
+                digitalWriteFast(port, HIGH);
+            }
+            else
+            {
+                digitalWriteFast(port, LOW);
+            }
+        }
+        else // read port
+        {
+            Serial.println(digitalReadFast(port));
+        }
     }
-    else // read port
+    else
     {
-      Serial.println(digitalReadFast(port));
+        interpreter_error(T_OUT_OF_RANGE);
     }
-  }
-  else
-  {
-    interpreter_error(T_OUT_OF_RANGE);
-  }
 }
 
-static volatile int* pointers_to_ADC_readings[] =
-{
-  &gSensorA0_dark, // SENSOR_RIGHT_MARK = A0;
-  &gSensorA1_dark, // SENSOR_1 = A1;
-  &gSensorA2_dark, // SENSOR_2 = A2;
-  &gSensorA3_dark, // SENSOR_3 = A3;
-  &gSensorA4_light, // SENSOR_4 = A4;
-  &gSensorA5_light, // SENSOR_LEFT_MARK = A5;
-  &Switch_ADC_value, // FUNCTION_PIN = A6;
-  &raw_BatteryVolts_adcValue, // BATTERY_VOLTS = A7;
+static volatile int *pointers_to_ADC_readings[] =
+    {
+        &gSensorA0_dark,            // SENSOR_RIGHT_MARK = A0;
+        &gSensorA1_dark,            // SENSOR_1 = A1;
+        &gSensorA2_dark,            // SENSOR_2 = A2;
+        &gSensorA3_dark,            // SENSOR_3 = A3;
+        &gSensorA4_light,           // SENSOR_4 = A4;
+        &gSensorA5_light,           // SENSOR_LEFT_MARK = A5;
+        &Switch_ADC_value,          // FUNCTION_PIN = A6;
+        &raw_BatteryVolts_adcValue, // BATTERY_VOLTS = A7;
 };
-
 
 /** @brief Reads an analogue pin or sets a PWM output.
  *  @return Void.
  */
 void analogue_control()
 {
-  // A2
-  // A9=255
-  int port = decode_input_value(1);
-  if(port >= 0)
-  {
-    if(inputString[inputIndex] == '=')
+    // A2
+    // A9=255
+    int port = decode_input_value(1);
+    if (port >= 0)
     {
-      // write PWM
-      //
-      int value = decode_input_value(inputIndex+1);
-      if(value >= 0)
-      {
-        analogWrite(port, value);
-      }
-      else
-      {
-        interpreter_error(T_OUT_OF_RANGE);
-      }
+        if (inputString[inputIndex] == '=')
+        {
+            // write PWM
+            //
+            int value = decode_input_value(inputIndex + 1);
+            if (value >= 0)
+            {
+                analogWrite(port, value);
+            }
+            else
+            {
+                interpreter_error(T_OUT_OF_RANGE);
+            }
+        }
+        else // read port
+        {
+            if (port >= 0 or port <= 7)
+            {
+                Serial.println(*(pointers_to_ADC_readings[port]));
+            }
+            else
+            {
+                interpreter_error(T_OUT_OF_RANGE);
+            }
+        }
     }
-    else // read port
+    else
     {
-      if(port >= 0 or port <= 7)
-      {
-        Serial.println(*(pointers_to_ADC_readings[port]));
-      }
-      else
-      {
         interpreter_error(T_OUT_OF_RANGE);
-      }
     }
-  }
-  else
-  {
-    interpreter_error(T_OUT_OF_RANGE);
-  }
 }
 
 /** @brief Turns a specific motor PWM to a specific value (and also set direction)
@@ -604,254 +607,248 @@ void analogue_control()
  */
 void motor_control()
 {
-  int motor = decode_input_value(1);
-  if(motor >= 0)
-  {
-    if(inputString[inputIndex] == '=')
+    int motor = decode_input_value(1);
+    if (motor >= 0)
     {
-      // write PWM
-      //
-      int motorPWM = decode_input_value_signed(inputIndex+1);
-      if(motor==1)
-      {
-        setLeftMotorPWM(motorPWM);
-      }
-      else
-      {
-        setRightMotorPWM(motorPWM);
-      }
+        if (inputString[inputIndex] == '=')
+        {
+            // write PWM
+            //
+            int motorPWM = decode_input_value_signed(inputIndex + 1);
+            if (motor == 1)
+            {
+                setLeftMotorPWM(motorPWM);
+            }
+            else
+            {
+                setRightMotorPWM(motorPWM);
+            }
+        }
+        else // read motor
+        {
+            interpreter_error(T_READ_NOT_SUPPORTED);
+        }
     }
-    else // read motor
+    else
     {
-      interpreter_error(T_READ_NOT_SUPPORTED);
+        interpreter_error(T_OUT_OF_RANGE);
     }
-  }
-  else
-  {
-    interpreter_error(T_OUT_OF_RANGE);
-  }
 }
-
-
 
 /** @brief Reads or writes the motor encoder values
  *  @return Void.
  */
 void encoder_values()
 {
-  int motor = decode_input_value(1);
-  if(motor >= 0)
-  {
-    if(inputString[inputIndex] == '=')
+    int motor = decode_input_value(1);
+    if (motor >= 0)
     {
-      // write encoder
-      //
-      int32_t param = decode_input_value_signed(inputIndex+1);
-      if(motor==1)
-      {
-        encoderLeftCount = param;
-      }
-      else
-      {
-        encoderRightCount = param;
-      }
-    }
-    else // read motor
-    {
-      if(motor==1)
-      {
-        Serial.println(encoderLeftCount);
-      }
-      else
-      {
-        Serial.println(encoderRightCount);
-      }
-    }
-  }
-  else
-  {
-    char c = inputString[1];
-    if (c == 'h')
-    {
-      // read both encoder values ahead of time so print time doesn't offset.
-      int32_t left = encoderLeftCount;
-      int32_t right = encoderRightCount;
-      if (inputString[2] == 'z')
-      {
-        encoderLeftCount = 0;
-        encoderRightCount = 0;
-      }
-
-      Serial.print(left, HEX);
-      Serial.print(",");
-      Serial.println(right, HEX);
-    }
-    else if (c == 0 or c == 'z')
-    {
-      // read both encoder values ahead of time so print time doesn't offset.
-      int32_t left = encoderLeftCount;
-      int32_t right = encoderRightCount;
-      if (c == 'z')
-      {
-        encoderLeftCount = 0;
-        encoderRightCount = 0;
-      }
-      Serial.print(left);
-      Serial.print(",");
-      Serial.println(right);
+        if (inputString[inputIndex] == '=')
+        {
+            // write encoder
+            //
+            int32_t param = decode_input_value_signed(inputIndex + 1);
+            if (motor == 1)
+            {
+                encoderLeftCount = param;
+            }
+            else
+            {
+                encoderRightCount = param;
+            }
+        }
+        else // read motor
+        {
+            if (motor == 1)
+            {
+                Serial.println(encoderLeftCount);
+            }
+            else
+            {
+                Serial.println(encoderRightCount);
+            }
+        }
     }
     else
     {
-      interpreter_error(T_OUT_OF_RANGE);
-    }
-  }
-}
+        char c = inputString[1];
+        if (c == 'h')
+        {
+            // read both encoder values ahead of time so print time doesn't offset.
+            int32_t left = encoderLeftCount;
+            int32_t right = encoderRightCount;
+            if (inputString[2] == 'z')
+            {
+                encoderLeftCount = 0;
+                encoderRightCount = 0;
+            }
 
+            Serial.print(left, HEX);
+            Serial.print(",");
+            Serial.println(right, HEX);
+        }
+        else if (c == 0 or c == 'z')
+        {
+            // read both encoder values ahead of time so print time doesn't offset.
+            int32_t left = encoderLeftCount;
+            int32_t right = encoderRightCount;
+            if (c == 'z')
+            {
+                encoderLeftCount = 0;
+                encoderRightCount = 0;
+            }
+            Serial.print(left);
+            Serial.print(",");
+            Serial.println(right);
+        }
+        else
+        {
+            interpreter_error(T_OUT_OF_RANGE);
+        }
+    }
+}
 
 /** @brief Selects the left and right motor voltages
  *  @return Void.
  */
 void motor_control_dual_voltage()
 {
-  float motor_left = decode_input_value_float(1);
-  if(inputString[inputIndex] == ',')
-  {
-    // write PWM
-    //
-    float motor_right = decode_input_value_float(inputIndex+1);
-    setMotorVolts(motor_left, motor_right);   // should this be float or what?
-  }
-  else // no comma
-  {
-    interpreter_error(T_UNEXPECTED_TOKEN);
-  }
+    float motor_left = decode_input_value_float(1);
+    if (inputString[inputIndex] == ',')
+    {
+        // write PWM
+        //
+        float motor_right = decode_input_value_float(inputIndex + 1);
+        setMotorVolts(motor_left, motor_right); // should this be float or what?
+    }
+    else // no comma
+    {
+        interpreter_error(T_UNEXPECTED_TOKEN);
+    }
 }
-
 
 /** @brief Reads and writes stored parameters
  *  @return Void.
  */
 void stored_parameter_control()
 {
-  int param_number = decode_input_value(1);
-  if(param_number >= 0 and param_number < NUM_STORED_PARAMS)
-  {
-    if(inputString[inputIndex] == '=')
+    int param_number = decode_input_value(1);
+    if (param_number >= 0 and param_number < NUM_STORED_PARAMS)
     {
-      // write param
-      //
-      float param = decode_input_value_float(inputIndex+1);
-      stored_params[param_number] = param;
-      EEPROM.put(param_number*4, param);
+        if (inputString[inputIndex] == '=')
+        {
+            // write param
+            //
+            float param = decode_input_value_float(inputIndex + 1);
+            stored_params[param_number] = param;
+            EEPROM.put(param_number * 4, param);
+        }
+        else // read param
+        {
+            Serial.println(stored_params[param_number], floating_decimal_places);
+        }
     }
-    else // read param
+    else if (param_number >= 100 and param_number < (100 + NUMBER_OF_BITFIELD_STORED_PARAMS))
     {
-        Serial.println(stored_params[param_number], floating_decimal_places);
-    }
-  }
-  else if(param_number >= 100 and param_number < (100+NUMBER_OF_BITFIELD_STORED_PARAMS))
-  {
-    uint8_t shift = param_number-100;
-    if(inputString[inputIndex] == '=')
-    {
-      uint32_t mask = 1UL << shift;
-      uint32_t bit_value = decode_input_value(inputIndex+1);
-      if(bit_value)
-      {
-        bitfield_stored_params |= mask;
-      }
-      else
-      {
-        bitfield_stored_params &= ~mask;
-      }
-      EEPROM.put(BITFIELD_ADDRESS, bitfield_stored_params);
-    }
-    else
-    {
-        Serial.println((bitfield_stored_params >> shift) & 1);
-    }
-  }
-  else
-  {
-    if(inputString[1]=='a')
-    {
-      for(int i=0; i<NUM_STORED_PARAMS; i++)
-      {
-        Serial.println(stored_params[i], floating_decimal_places);
-      }
-    }
-    else if(inputString[1]=='b')
-    {
-      for(int i=0; i<NUMBER_OF_BITFIELD_STORED_PARAMS; i++)
-      {
-        Serial.println((bitfield_stored_params & (1UL<<i))?1:0);
-      }
-    }
-    else if(inputString[1]=='d')
-    {
-      const float* p = stored_parameters_default_values;
-      for(int i=0; i<NUM_STORED_PARAMS; i++)
-      {
-        EEPROM.put(i*4, *p);
-        stored_params[i] = *p++;
-      }
-      EEPROM.put(BITFIELD_ADDRESS, bitfield_default_values);
-      bitfield_stored_params = bitfield_default_values;
+        uint8_t shift = param_number - 100;
+        if (inputString[inputIndex] == '=')
+        {
+            uint32_t mask = 1UL << shift;
+            uint32_t bit_value = decode_input_value(inputIndex + 1);
+            if (bit_value)
+            {
+                bitfield_stored_params |= mask;
+            }
+            else
+            {
+                bitfield_stored_params &= ~mask;
+            }
+            EEPROM.put(BITFIELD_ADDRESS, bitfield_stored_params);
+        }
+        else
+        {
+            Serial.println((bitfield_stored_params >> shift) & 1);
+        }
     }
     else
     {
-      interpreter_error(T_OUT_OF_RANGE);
+        if (inputString[1] == 'a')
+        {
+            for (int i = 0; i < NUM_STORED_PARAMS; i++)
+            {
+                Serial.println(stored_params[i], floating_decimal_places);
+            }
+        }
+        else if (inputString[1] == 'b')
+        {
+            for (int i = 0; i < NUMBER_OF_BITFIELD_STORED_PARAMS; i++)
+            {
+                Serial.println((bitfield_stored_params & (1UL << i)) ? 1 : 0);
+            }
+        }
+        else if (inputString[1] == 'd')
+        {
+            const float *p = stored_parameters_default_values;
+            for (int i = 0; i < NUM_STORED_PARAMS; i++)
+            {
+                EEPROM.put(i * 4, *p);
+                stored_params[i] = *p++;
+            }
+            EEPROM.put(BITFIELD_ADDRESS, bitfield_default_values);
+            bitfield_stored_params = bitfield_default_values;
+        }
+        else
+        {
+            interpreter_error(T_OUT_OF_RANGE);
+        }
     }
-  }
 }
-
 
 /** @brief Reads the parameters into RAM. If Magic number not found will default all parameters.
  *  @return Void.
  */
 void init_stored_parameters()
 {
-  uint32_t magic = 0;
-  EEPROM.get(MAGIC_ADDRESS, magic);
-  if(magic != MAGIC_NUMBER)
-  {
-    Serial.println("@Defaulting Params");
-    // default values here
-    const float* p = stored_parameters_default_values;
-    for(int i=0; i<NUM_STORED_PARAMS; i++)
+    uint32_t magic = 0;
+    EEPROM.get(MAGIC_ADDRESS, magic);
+    if (magic != MAGIC_NUMBER)
     {
-      // we use write here, not update
-      EEPROM.put(i*4, *p++);
+        Serial.println("@Defaulting Params");
+        // default values here
+        const float *p = stored_parameters_default_values;
+        for (int i = 0; i < NUM_STORED_PARAMS; i++)
+        {
+            // we use write here, not update
+            EEPROM.put(i * 4, *p++);
+        }
+        EEPROM.put(BITFIELD_ADDRESS, bitfield_default_values);
+        // finally write magic back
+        EEPROM.put(MAGIC_ADDRESS, MAGIC_NUMBER);
     }
-    EEPROM.put(BITFIELD_ADDRESS, bitfield_default_values);
-    // finally write magic back
-    EEPROM.put(MAGIC_ADDRESS, MAGIC_NUMBER);
-  }
 
-  for(int i=0; i<NUM_STORED_PARAMS; i++)
-  {
-    float f;
-    EEPROM.get(i*4, f);
-    stored_params[i] = f;
-  }
-  EEPROM.get(BITFIELD_ADDRESS, bitfield_stored_params);
+    for (int i = 0; i < NUM_STORED_PARAMS; i++)
+    {
+        float f;
+        EEPROM.get(i * 4, f);
+        stored_params[i] = f;
+    }
+    EEPROM.get(BITFIELD_ADDRESS, bitfield_stored_params);
 }
-
 
 /** @brief Turns command line interpreter verbose error messages on and off
  *  @return Void.
  */
 void verbose_control()
 {
-  int param = decode_input_value(1);
-  if(param == 0 or param == 1)
-  {
-    verbose_errors = param;
-  }
-  else
-  {
-    interpreter_error(T_OUT_OF_RANGE);
-  }
+    int param = decode_input_value(1);
+    if (param == 0 or param == 1)
+    {
+        verbose_errors = param;
+    }
+    else
+    {
+        interpreter_error(T_OUT_OF_RANGE);
+    }
 }
 
 /** @brief Turns command line interpreter echo of input on and off
@@ -859,15 +856,15 @@ void verbose_control()
  */
 void echo_control()
 {
-  int param = decode_input_value(1);
-  if(param == 0 or param == 1)
-  {
-    interpreter_echo = param;
-  }
-  else
-  {
-    interpreter_error(T_OUT_OF_RANGE);
-  }
+    int param = decode_input_value(1);
+    if (param == 0 or param == 1)
+    {
+        interpreter_echo = param;
+    }
+    else
+    {
+        interpreter_error(T_OUT_OF_RANGE);
+    }
 }
 
 /** @brief Turns the main emitter LED on and off.
@@ -875,15 +872,15 @@ void echo_control()
  */
 void emitter_control()
 {
-  int param = decode_input_value(1);
-  if(param == 0 or param == 1)
-  {
-    emitter_on = param;
-  }
-  else
-  {
-    interpreter_error(T_OUT_OF_RANGE);
-  }
+    int param = decode_input_value(1);
+    if (param == 0 or param == 1)
+    {
+        emitter_on = param;
+    }
+    else
+    {
+        interpreter_error(T_OUT_OF_RANGE);
+    }
 }
 
 /** @brief  Echos a number to stdout from the command line.
@@ -891,28 +888,28 @@ void emitter_control()
  */
 void echo_command()
 {
-  int param = inputString[1];
-  if(param == 'F')
-  {
-    Serial.println(decode_input_value_float(2), floating_decimal_places);
-    return;
-  }
-  if(param == 'U')
-  {
-    Serial.println(decode_input_value(2));
-    return;
-  }
-  if(param == 'S')
-  {
-    Serial.println(decode_input_value_signed(2));
-    return;
-  }
-  if(param == '*')
-  {
-    Serial.println(inputString);
-    return;
-  }
-  Serial.println(decode_input_value_float(1), floating_decimal_places);
+    int param = inputString[1];
+    if (param == 'F')
+    {
+        Serial.println(decode_input_value_float(2), floating_decimal_places);
+        return;
+    }
+    if (param == 'U')
+    {
+        Serial.println(decode_input_value(2));
+        return;
+    }
+    if (param == 'S')
+    {
+        Serial.println(decode_input_value_signed(2));
+        return;
+    }
+    if (param == '*')
+    {
+        Serial.println(inputString);
+        return;
+    }
+    Serial.println(decode_input_value_float(1), floating_decimal_places);
 }
 
 /** @brief  Allows configuration of the Pin Mode from the command line.
@@ -920,50 +917,49 @@ void echo_command()
  */
 void pinMode_command()
 {
-  int pin_number = decode_input_value(1);
-  if(pin_number >= 0)
-  {
-    if(inputString[inputIndex] == '=')
+    int pin_number = decode_input_value(1);
+    if (pin_number >= 0)
     {
-      // write PWM
-      //
-      char mode = inputString[inputIndex+1];
-      if(mode == 'I')
-      {
-        pinMode(pin_number, INPUT);
-      }
-      else if(mode == 'O')
-      {
-        pinMode(pin_number, OUTPUT);
-      }
-      else if(mode == 'U')
-      {
-        pinMode(pin_number, INPUT_PULLUP);
-      }
-      else
-      {
-        interpreter_error(T_UNEXPECTED_TOKEN);
-      }
+        if (inputString[inputIndex] == '=')
+        {
+            // write PWM
+            //
+            char mode = inputString[inputIndex + 1];
+            if (mode == 'I')
+            {
+                pinMode(pin_number, INPUT);
+            }
+            else if (mode == 'O')
+            {
+                pinMode(pin_number, OUTPUT);
+            }
+            else if (mode == 'U')
+            {
+                pinMode(pin_number, INPUT_PULLUP);
+            }
+            else
+            {
+                interpreter_error(T_UNEXPECTED_TOKEN);
+            }
+        }
+        else // read?
+        {
+            interpreter_error(T_READ_NOT_SUPPORTED);
+        }
     }
-    else // read?
+    else
     {
-      interpreter_error(T_READ_NOT_SUPPORTED);
+        interpreter_error(T_OUT_OF_RANGE);
     }
-  }
-  else
-  {
-    interpreter_error(T_OUT_OF_RANGE);
-  }
 }
-
 
 /** @brief  Stops both motors
  *  @return Void.
  */
 void stop_motors_and_everything_command()
 {
-  setMotorVolts(0, 0);
-  // add action stop here as well
+    setMotorVolts(0, 0);
+    // add action stop here as well
 }
 
 /** @brief  Prints the sensors (in various formats)
@@ -971,23 +967,23 @@ void stop_motors_and_everything_command()
  */
 void print_sensors_control_command()
 {
-  int mode = inputString[1];
-  if (mode == 'h')
-  {
-    print_sensors_control('h'); // hex
-  }
-  else if (mode == 0)
-  {
-    print_sensors_control('d'); // decimal
-  }
-  else  if (mode == 'r')
-  {
-    print_sensors_control('r'); // raw light and dark
-  }
-  else
-  {
-    interpreter_error(T_UNEXPECTED_TOKEN);
-  }
+    int mode = inputString[1];
+    if (mode == 'h')
+    {
+        print_sensors_control('h'); // hex
+    }
+    else if (mode == 0)
+    {
+        print_sensors_control('d'); // decimal
+    }
+    else if (mode == 'r')
+    {
+        print_sensors_control('r'); // raw light and dark
+    }
+    else
+    {
+        interpreter_error(T_UNEXPECTED_TOKEN);
+    }
 }
 
 #define SERIAL_IN_CAPTURE 0
@@ -1001,215 +997,221 @@ char hex[] = "0123456789ABCDEF";
  */
 void print_serial_capture_read_buff()
 {
-  for(int i=0; i< 256; i+= 16)
-  {
-    for(int j=0; j<16; j++)
+    for (int i = 0; i < 256; i += 16)
     {
-      uint8_t offset = serial_capture_read_index + j + i;
-      char c = serial_capture_read_buff[offset];
-      if (c< 32 or c > 126) {
-        Serial.print(hex[c>>4]);
-        Serial.print(hex[c&0xF]);
-      }
-      else
-      {
-        Serial.print(' ');
-        Serial.print(c);
-      }
+        for (int j = 0; j < 16; j++)
+        {
+            uint8_t offset = serial_capture_read_index + j + i;
+            char c = serial_capture_read_buff[offset];
+            if (c < 32 or c > 126)
+            {
+                Serial.print(hex[c >> 4]);
+                Serial.print(hex[c & 0xF]);
+            }
+            else
+            {
+                Serial.print(' ');
+                Serial.print(c);
+            }
+        }
+        Serial.println("");
     }
-    Serial.println("");
-  }
 }
 #endif
 
-
-
-void not_implemented(){
-  interpreter_error(T_UNKNOWN_COMMAND, inputString);
+void not_implemented()
+{
+    interpreter_error(T_UNKNOWN_COMMAND, inputString);
 }
 
 typedef void (*fptr)();
 
 const PROGMEM fptr PROGMEM cmd2[] =
-{
-  not_implemented, // ' '
-  not_implemented, // '!'
-  not_implemented, // '"'
-  not_implemented, // '#'
-  stored_parameter_control, // '$'
-  not_implemented, // '%'
-  not_implemented, // '&'
-  not_implemented, // '''
-  not_implemented, // '('
-  not_implemented, // ')'
-  emitter_control, // '*'
-  not_implemented, // '+'
-  not_implemented, // ','
-  not_implemented, // '-'
-  not_implemented, // '.'
-  not_implemented, // '/'
-  not_implemented, // '0'
-  not_implemented, // '1'
-  not_implemented, // '2'
-  not_implemented, // '3'
-  not_implemented, // '4'
-  not_implemented, // '5'
-  not_implemented, // '6'
-  not_implemented, // '7'
-  not_implemented, // '8'
-  not_implemented, // '9'
-  not_implemented, // ':'
-  not_implemented, // ';'
-  not_implemented, // '<'
-  echo_command, // '='
-  not_implemented, // '>'
-  ok, // '?'
-  not_implemented, // '@'
-  analogue_control, // 'A'
-  not_implemented, // 'B'
-  encoder_values, // 'C'
-  digital_pin_control, // 'D'
-  echo_control, // 'E'
-  not_implemented, // 'F'
-  not_implemented, // 'G'
-  not_implemented, // 'H'
-  not_implemented, // 'I'
-  not_implemented, // 'J'
-  not_implemented, // 'K'
-  not_implemented, // 'L'
-  motor_control, // 'M'
-  motor_control_dual_voltage, // 'N'
-  not_implemented, // 'O'
-  pinMode_command, // 'P'
-  not_implemented, // 'Q'
-  not_implemented, // 'R'
-  print_sensors_control_command, // 'S'
-  not_implemented, // 'T'
-  not_implemented, // 'U'
-  verbose_control, // 'V'
-  not_implemented, // 'W'
-  not_implemented, // 'X'
-  not_implemented, // 'Y'
-  not_implemented, // 'Z'
-  not_implemented, // '['
+    {
+        not_implemented,               // ' '
+        not_implemented,               // '!'
+        not_implemented,               // '"'
+        not_implemented,               // '#'
+        stored_parameter_control,      // '$'
+        not_implemented,               // '%'
+        not_implemented,               // '&'
+        not_implemented,               // '''
+        not_implemented,               // '('
+        not_implemented,               // ')'
+        emitter_control,               // '*'
+        not_implemented,               // '+'
+        not_implemented,               // ','
+        not_implemented,               // '-'
+        not_implemented,               // '.'
+        not_implemented,               // '/'
+        not_implemented,               // '0'
+        not_implemented,               // '1'
+        not_implemented,               // '2'
+        not_implemented,               // '3'
+        not_implemented,               // '4'
+        not_implemented,               // '5'
+        not_implemented,               // '6'
+        not_implemented,               // '7'
+        not_implemented,               // '8'
+        not_implemented,               // '9'
+        not_implemented,               // ':'
+        not_implemented,               // ';'
+        not_implemented,               // '<'
+        echo_command,                  // '='
+        not_implemented,               // '>'
+        ok,                            // '?'
+        not_implemented,               // '@'
+        analogue_control,              // 'A'
+        not_implemented,               // 'B'
+        encoder_values,                // 'C'
+        digital_pin_control,           // 'D'
+        echo_control,                  // 'E'
+        not_implemented,               // 'F'
+        not_implemented,               // 'G'
+        not_implemented,               // 'H'
+        not_implemented,               // 'I'
+        not_implemented,               // 'J'
+        not_implemented,               // 'K'
+        not_implemented,               // 'L'
+        motor_control,                 // 'M'
+        motor_control_dual_voltage,    // 'N'
+        not_implemented,               // 'O'
+        pinMode_command,               // 'P'
+        not_implemented,               // 'Q'
+        not_implemented,               // 'R'
+        print_sensors_control_command, // 'S'
+        not_implemented,               // 'T'
+        not_implemented,               // 'U'
+        verbose_control,               // 'V'
+        not_implemented,               // 'W'
+        not_implemented,               // 'X'
+        not_implemented,               // 'Y'
+        not_implemented,               // 'Z'
+        not_implemented,               // '['
 #if SERIAL_IN_CAPTURE
-  print_serial_capture_read_buff, // '\'
+        print_serial_capture_read_buff, // '\'
 #else
-  not_implemented, // '\'
+        not_implemented, // '\'
 #endif
-  not_implemented, // ']'
-  reset_state, // '^'
-  not_implemented, // '_'
-  not_implemented, // '`'
-  not_implemented, // 'a'
-  print_bat, // 'b'
-  not_implemented, // 'c'
-  not_implemented, // 'd'
-  print_encoders, // 'e'
-  not_implemented, // 'f'
-  not_implemented, // 'g'
-  ok, // 'h'
-  not_implemented, // 'i'
-  not_implemented, // 'j'
-  not_implemented, // 'k'
-  led, // 'l'
-  motor_test, // 'm'
-  not_implemented, // 'n'
-  not_implemented, // 'o'
-  not_implemented, // 'p'
-  not_implemented, // 'q'
-  print_encoder_setup, // 'r'
-  print_switches, // 's'
-  not_implemented, // 't'
-  not_implemented, // 'u'
-  show_version, // 'v'
-  not_implemented, // 'w'     // used to be print_wall_sensors
-  stop_motors_and_everything_command, // 'x'
-  not_implemented, // 'y'
-  zero_encoders, // 'z'
-  not_implemented, // '{'
-  not_implemented, // '|'
-  not_implemented, // '}'
+        not_implemented,                    // ']'
+        reset_state,                        // '^'
+        not_implemented,                    // '_'
+        not_implemented,                    // '`'
+        not_implemented,                    // 'a'
+        print_bat,                          // 'b'
+        not_implemented,                    // 'c'
+        not_implemented,                    // 'd'
+        print_encoders,                     // 'e'
+        not_implemented,                    // 'f'
+        not_implemented,                    // 'g'
+        ok,                                 // 'h'
+        not_implemented,                    // 'i'
+        not_implemented,                    // 'j'
+        not_implemented,                    // 'k'
+        led,                                // 'l'
+        motor_test,                         // 'm'
+        not_implemented,                    // 'n'
+        not_implemented,                    // 'o'
+        not_implemented,                    // 'p'
+        not_implemented,                    // 'q'
+        print_encoder_setup,                // 'r'
+        print_switches,                     // 's'
+        not_implemented,                    // 't'
+        not_implemented,                    // 'u'
+        show_version,                       // 'v'
+        not_implemented,                    // 'w'     // used to be print_wall_sensors
+        stop_motors_and_everything_command, // 'x'
+        not_implemented,                    // 'y'
+        zero_encoders,                      // 'z'
+        not_implemented,                    // '{'
+        not_implemented,                    // '|'
+        not_implemented,                    // '}'
 };
 const int CMD2_SIZE = sizeof(cmd2) / sizeof(fptr);
-
 
 /** @brief  Finds the single character command from a list.
  *  @return Void.
  */
-void parse_cmd() {
-  int command = inputString[0] - ' ';
-  if (command >= CMD2_SIZE) {
-    interpreter_error(T_UNKNOWN_COMMAND);
-    return;
-  }
-  fptr f = fptr(pgm_read_ptr(cmd2 + command));
-  f();
+void parse_cmd()
+{
+    int command = inputString[0] - ' ';
+    if (command >= CMD2_SIZE)
+    {
+        interpreter_error(T_UNKNOWN_COMMAND);
+        return;
+    }
+    fptr f = fptr(pgm_read_ptr(cmd2 + command));
+    f();
 }
 
 #define CTRL_C 0x03
 #define BACKSPACE 0x08
 #define CTRL_X 0x18
 
-
-
 /** @brief  Command line interpreter.
  *  @return Void.
  */
 void interpreter()
 {
-    while (Serial.available()) {
-      char inChar = (char)Serial.read();      // get the new byte:
+    while (Serial.available())
+    {
+        char inChar = (char)Serial.read(); // get the new byte:
 #if SERIAL_IN_CAPTURE
-  serial_capture_read_buff[serial_capture_read_index++]=inChar;
+        serial_capture_read_buff[serial_capture_read_index++] = inChar;
 #endif
 
-      if(inChar > ' ')
-      {
-        if(interpreter_echo) { Serial.write(inChar); }
-
-        inputString[inputIndex++] = inChar;      // add it to the inputString:
-        if(inputIndex == MAX_INPUT_SIZE)
+        if (inChar > ' ')
         {
-            interpreter_error(T_LINE_TOO_LONG);
-            inputIndex = 0;
-        }
-      }
-      else
-      {
-        // if the incoming character is a newline interpret it
-        if(inChar == '\n')
-        {
-            if(interpreter_echo) { Serial.write(inChar); }
-            if(inputIndex)
+            if (interpreter_echo)
             {
-              inputString[inputIndex] = 0;  // zero terminate
-              parse_cmd();
-              inputIndex = 0;
+                Serial.write(inChar);
             }
-            else
+
+            inputString[inputIndex++] = inChar; // add it to the inputString:
+            if (inputIndex == MAX_INPUT_SIZE)
             {
-              // what do we want to print here? OK for V0?
-              interpreter_error(T_OK);
+                interpreter_error(T_LINE_TOO_LONG);
+                inputIndex = 0;
             }
         }
-        else if(inChar == CTRL_X or inChar == CTRL_C)
+        else
         {
-          if(inChar == CTRL_X)
-          {
-            stop_motors_and_everything_command();
-          }
-          inputIndex = 0;
-          Serial.println();
-        }
-        else if(inChar == BACKSPACE and inputIndex != 0)
-        {
-            inputIndex--;
+            // if the incoming character is a newline interpret it
+            if (inChar == '\n')
+            {
+                if (interpreter_echo)
+                {
+                    Serial.write(inChar);
+                }
+                if (inputIndex)
+                {
+                    inputString[inputIndex] = 0; // zero terminate
+                    parse_cmd();
+                    inputIndex = 0;
+                }
+                else
+                {
+                    // what do we want to print here? OK for V0?
+                    interpreter_error(T_OK);
+                }
+            }
+            else if (inChar == CTRL_X or inChar == CTRL_C)
+            {
+                if (inChar == CTRL_X)
+                {
+                    stop_motors_and_everything_command();
+                }
+                inputIndex = 0;
+                Serial.println();
+            }
+            else if (inChar == BACKSPACE and inputIndex != 0)
+            {
+                inputIndex--;
 
-            // This sequence depends on terminal emulator
-            Serial.print("\x08 \x08");
-            //Serial.print("\x08");
+                // This sequence depends on terminal emulator
+                Serial.print("\x08 \x08");
+                //Serial.print("\x08");
+            }
         }
-      }
     }
 }

--- a/motor_control.cpp
+++ b/motor_control.cpp
@@ -7,7 +7,7 @@
        https://ukmars.org/
        https://github.com/ukmars/ukmarsbot
        https://github.com/robzed/pizero_for_ukmarsbot
-       
+
   MIT License
 
   Copyright (c) 2020-2021 Rob Probin & Peter Harrison
@@ -31,69 +31,80 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
   SOFTWARE.
 */
-#include <Arduino.h>
 #include "digitalWriteFast.h"
 #include "hardware_pins.h"
 #include "public.h"
 #include "robot_config.h"
+#include <Arduino.h>
 
 /***
  * Global variables
  */
 
-
-
-void motorSetup() {
-  pinMode(MOTOR_LEFT_DIR, OUTPUT);
-  pinMode(MOTOR_RIGHT_DIR, OUTPUT);
-  pinMode(MOTOR_LEFT_PWM, OUTPUT);
-  pinMode(MOTOR_RIGHT_PWM, OUTPUT);
-  digitalWriteFast(MOTOR_LEFT_PWM, 0);
-  digitalWriteFast(MOTOR_LEFT_DIR, 0);
-  digitalWriteFast(MOTOR_RIGHT_PWM, 0);
-  digitalWriteFast(MOTOR_RIGHT_DIR, 0);
-}
-
-void setLeftMotorPWM(int pwm) {
-  pwm = MOTOR_LEFT_POLARITY * constrain(pwm, -255, 255);
-  if (pwm < 0) {
-    digitalWriteFast(MOTOR_LEFT_DIR, 1);
-    analogWrite(MOTOR_LEFT_PWM, -pwm);
-  } else {
+void motorSetup()
+{
+    pinMode(MOTOR_LEFT_DIR, OUTPUT);
+    pinMode(MOTOR_RIGHT_DIR, OUTPUT);
+    pinMode(MOTOR_LEFT_PWM, OUTPUT);
+    pinMode(MOTOR_RIGHT_PWM, OUTPUT);
+    digitalWriteFast(MOTOR_LEFT_PWM, 0);
     digitalWriteFast(MOTOR_LEFT_DIR, 0);
-    analogWrite(MOTOR_LEFT_PWM, pwm);
-  }
-}
-
-void setRightMotorPWM(int pwm) {
-  pwm = MOTOR_RIGHT_POLARITY * constrain(pwm, -255, 255);
-  if (pwm < 0) {
-    digitalWriteFast(MOTOR_RIGHT_DIR, 1);
-    analogWrite(MOTOR_RIGHT_PWM, -pwm);
-  } else {
+    digitalWriteFast(MOTOR_RIGHT_PWM, 0);
     digitalWriteFast(MOTOR_RIGHT_DIR, 0);
-    analogWrite(MOTOR_RIGHT_PWM, pwm);
-  }
 }
 
-void setMotorPWM(int left, int right) {
-  setLeftMotorPWM(left);
-  setRightMotorPWM(right);
+void setLeftMotorPWM(int pwm)
+{
+    pwm = MOTOR_LEFT_POLARITY * constrain(pwm, -255, 255);
+    if (pwm < 0)
+    {
+        digitalWriteFast(MOTOR_LEFT_DIR, 1);
+        analogWrite(MOTOR_LEFT_PWM, -pwm);
+    }
+    else
+    {
+        digitalWriteFast(MOTOR_LEFT_DIR, 0);
+        analogWrite(MOTOR_LEFT_PWM, pwm);
+    }
 }
 
-void setLeftMotorVolts(float volts) {
-  volts = constrain(volts, -MAX_MOTOR_VOLTS, MAX_MOTOR_VOLTS);
-  int motorPWM = (int)((255.0f * volts) / get_BatteryVolts());
-  setLeftMotorPWM(motorPWM);
+void setRightMotorPWM(int pwm)
+{
+    pwm = MOTOR_RIGHT_POLARITY * constrain(pwm, -255, 255);
+    if (pwm < 0)
+    {
+        digitalWriteFast(MOTOR_RIGHT_DIR, 1);
+        analogWrite(MOTOR_RIGHT_PWM, -pwm);
+    }
+    else
+    {
+        digitalWriteFast(MOTOR_RIGHT_DIR, 0);
+        analogWrite(MOTOR_RIGHT_PWM, pwm);
+    }
 }
 
-void setRightMotorVolts(float volts) {
-  volts = constrain(volts, -MAX_MOTOR_VOLTS, MAX_MOTOR_VOLTS);
-  int motorPWM = (int)((255.0f * volts) / get_BatteryVolts());
-  setRightMotorPWM(motorPWM);
+void setMotorPWM(int left, int right)
+{
+    setLeftMotorPWM(left);
+    setRightMotorPWM(right);
 }
 
-void setMotorVolts(float left, float right) {
-  setLeftMotorVolts(left);
-  setRightMotorVolts(right);
+void setLeftMotorVolts(float volts)
+{
+    volts = constrain(volts, -MAX_MOTOR_VOLTS, MAX_MOTOR_VOLTS);
+    int motorPWM = (int)((255.0f * volts) / get_BatteryVolts());
+    setLeftMotorPWM(motorPWM);
+}
+
+void setRightMotorVolts(float volts)
+{
+    volts = constrain(volts, -MAX_MOTOR_VOLTS, MAX_MOTOR_VOLTS);
+    int motorPWM = (int)((255.0f * volts) / get_BatteryVolts());
+    setRightMotorPWM(motorPWM);
+}
+
+void setMotorVolts(float left, float right)
+{
+    setLeftMotorVolts(left);
+    setRightMotorVolts(right);
 }

--- a/public.h
+++ b/public.h
@@ -72,11 +72,10 @@ typedef unsigned time_measure_t;
 #else
 #define TIME_START(START_VARIABLE)
 #define TIME_END(START_VARIABLE, END_VARIABLE)
-#define TIME_DEFINE_VARIABLE(VARIABLE) 
+#define TIME_DEFINE_VARIABLE(VARIABLE)
 #endif
 
 // Other constants
 const int floating_decimal_places = 3;
-
 
 #endif

--- a/robot_config.h
+++ b/robot_config.h
@@ -3,10 +3,9 @@
 
 //
 // Robot Specific Configuration
-// 
+//
 // Depending on how you wired up your motor and encoders, you might need to tweak these values
-// 
-
+//
 
 // Encoder polarity is either 1 or -1 and is used to account for reversal of the encoder phases
 // The encoders should count up when the robot is moving forward.
@@ -17,7 +16,6 @@
 // Setting a positive voltage always moves the robot forwards
 #define MOTOR_LEFT_POLARITY (-1)
 #define MOTOR_RIGHT_POLARITY (1)
-
 
 /***
  * Global robot characteristic constants
@@ -31,7 +29,7 @@ const float WHEEL_SEPARATION = 75.2;
 const float MM_PER_COUNT = (PI * WHEEL_DIAMETER) / (2 * COUNTS_PER_ROTATION * GEAR_RATIO);
 const float DEG_PER_COUNT = (360.0 * MM_PER_COUNT) / (PI * WHEEL_SEPARATION);
 
-// The is the maximum voltage the motor should be driven at when 
+// The is the maximum voltage the motor should be driven at when
 // using voltage based control.
 const float MAX_MOTOR_VOLTS = 6.0f;
 

--- a/sensors_control.cpp
+++ b/sensors_control.cpp
@@ -31,11 +31,11 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
   SOFTWARE.
 */
-#include <Arduino.h>
 #include "digitalWriteFast.h"
 #include "hardware_pins.h"
-#include <util/atomic.h>
 #include "public.h"
+#include <Arduino.h>
+#include <util/atomic.h>
 /***
  * Global variables
  */
@@ -54,116 +54,129 @@ volatile int gSensorA2_light;
 volatile int gSensorA3_light;
 volatile int gSensorA4_light;
 volatile int gSensorA5_light;
-void analogueSetup() {
-  // increase speed of ADC conversions to 28us each
-  // by changing the clock prescaler from 128 to 16
-  bitClear(ADCSRA, ADPS0);
-  bitClear(ADCSRA, ADPS1);
-  bitSet(ADCSRA, ADPS2);
+void analogueSetup()
+{
+    // increase speed of ADC conversions to 28us each
+    // by changing the clock prescaler from 128 to 16
+    bitClear(ADCSRA, ADPS0);
+    bitClear(ADCSRA, ADPS1);
+    bitSet(ADCSRA, ADPS2);
 }
 char emitter_on = 1;
 
-
-
-void sensors_control_setup() {
-  pinMode(EMITTER, OUTPUT);
-  digitalWriteFast(EMITTER, 0);  // be sure the emitter is off
-  analogueSetup();               // increase the ADC conversion speed
+void sensors_control_setup()
+{
+    pinMode(EMITTER, OUTPUT);
+    digitalWriteFast(EMITTER, 0); // be sure the emitter is off
+    analogueSetup();              // increase the ADC conversion speed
 }
 
-void print_hex2(int value) {
-  value >>= 2;         // get rid of button 2 bits - probably noise
-  value = constrain(value, 0, 255);
-  Serial.print(value / 16, HEX);
-  Serial.print(value % 16, HEX);
+void print_hex2(int value)
+{
+    value >>= 2; // get rid of button 2 bits - probably noise
+    value = constrain(value, 0, 255);
+    Serial.print(value / 16, HEX);
+    Serial.print(value % 16, HEX);
 }
 
-void print_sensors_control(char mode) {
-  int a0_dark;
-  int a1_dark;
-  int a2_dark;
-  int a3_dark;
-  int a4_dark;
-  int a5_dark;
-  int a0_lit;
-  int a1_lit;
-  int a2_lit;
-  int a3_lit;
-  int a4_lit;
-  int a5_lit;
-  const char comma = ',';
+void print_sensors_control(char mode)
+{
+    int a0_dark;
+    int a1_dark;
+    int a2_dark;
+    int a3_dark;
+    int a4_dark;
+    int a5_dark;
+    int a0_lit;
+    int a1_lit;
+    int a2_lit;
+    int a3_lit;
+    int a4_lit;
+    int a5_lit;
+    const char comma = ',';
 
-  // read the sensors
-  ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-    a0_dark = gSensorA0_dark;
-    a0_lit = gSensorA0_light;
-  }
-  ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-    a1_dark = gSensorA1_dark;
-    a1_lit = gSensorA1_light;
-  }
-  ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-    a2_dark = gSensorA2_dark;
-    a2_lit = gSensorA2_light;
-  }
-  ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-    a3_dark = gSensorA3_dark;
-    a3_lit = gSensorA3_light;
-  }
-  ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-    a4_dark = gSensorA4_dark;
-    a4_lit = gSensorA4_light;
-  }
-  ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-    a5_dark = gSensorA5_dark;
-    a5_lit = gSensorA5_light;
-  }
+    // read the sensors
+    ATOMIC_BLOCK(ATOMIC_RESTORESTATE)
+    {
+        a0_dark = gSensorA0_dark;
+        a0_lit = gSensorA0_light;
+    }
+    ATOMIC_BLOCK(ATOMIC_RESTORESTATE)
+    {
+        a1_dark = gSensorA1_dark;
+        a1_lit = gSensorA1_light;
+    }
+    ATOMIC_BLOCK(ATOMIC_RESTORESTATE)
+    {
+        a2_dark = gSensorA2_dark;
+        a2_lit = gSensorA2_light;
+    }
+    ATOMIC_BLOCK(ATOMIC_RESTORESTATE)
+    {
+        a3_dark = gSensorA3_dark;
+        a3_lit = gSensorA3_light;
+    }
+    ATOMIC_BLOCK(ATOMIC_RESTORESTATE)
+    {
+        a4_dark = gSensorA4_dark;
+        a4_lit = gSensorA4_light;
+    }
+    ATOMIC_BLOCK(ATOMIC_RESTORESTATE)
+    {
+        a5_dark = gSensorA5_dark;
+        a5_lit = gSensorA5_light;
+    }
 
-  if (mode == 'd') {  // the default is decimal differences
-    Serial.print(max(a0_lit - a0_dark, 0));
-    Serial.print(comma);
-    Serial.print(max(a1_lit - a1_dark, 0));
-    Serial.print(comma);
-    Serial.print(max(a2_lit - a2_dark, 0));
-    Serial.print(comma);
-    Serial.print(max(a3_lit - a3_dark, 0));
-    Serial.print(comma);
-    Serial.print(max(a4_lit - a4_dark, 0));
-    Serial.print(comma);
-    Serial.print(max(a5_lit - a5_dark, 0));
-  } else if (mode == 'h') {  // display differences as hex values
-    print_hex2(a0_lit - a0_dark);
-    print_hex2(a1_lit - a1_dark);
-    print_hex2(a2_lit - a2_dark);
-    print_hex2(a3_lit - a3_dark);
-    print_hex2(a4_lit - a4_dark);
-    print_hex2(a5_lit - a5_dark);
-  } else if (mode == 'r') { // display both dark and lit values
-    Serial.print(a0_dark);
-    Serial.print(comma);
-    Serial.print(a1_dark);
-    Serial.print(comma);
-    Serial.print(a2_dark);
-    Serial.print(comma);
-    Serial.print(a3_dark);
-    Serial.print(comma);
-    Serial.print(a4_dark);
-    Serial.print(comma);
-    Serial.print(a5_dark);
-    Serial.print(comma);
-    Serial.print(' ');
-    Serial.print(' ');
-    Serial.print(a0_lit);
-    Serial.print(comma);
-    Serial.print(a1_lit);
-    Serial.print(comma);
-    Serial.print(a2_lit);
-    Serial.print(comma);
-    Serial.print(a3_lit);
-    Serial.print(comma);
-    Serial.print(a4_lit);
-    Serial.print(comma);
-    Serial.print(a5_lit);
-  }
-  Serial.println();
+    if (mode == 'd')
+    { // the default is decimal differences
+        Serial.print(max(a0_lit - a0_dark, 0));
+        Serial.print(comma);
+        Serial.print(max(a1_lit - a1_dark, 0));
+        Serial.print(comma);
+        Serial.print(max(a2_lit - a2_dark, 0));
+        Serial.print(comma);
+        Serial.print(max(a3_lit - a3_dark, 0));
+        Serial.print(comma);
+        Serial.print(max(a4_lit - a4_dark, 0));
+        Serial.print(comma);
+        Serial.print(max(a5_lit - a5_dark, 0));
+    }
+    else if (mode == 'h')
+    { // display differences as hex values
+        print_hex2(a0_lit - a0_dark);
+        print_hex2(a1_lit - a1_dark);
+        print_hex2(a2_lit - a2_dark);
+        print_hex2(a3_lit - a3_dark);
+        print_hex2(a4_lit - a4_dark);
+        print_hex2(a5_lit - a5_dark);
+    }
+    else if (mode == 'r')
+    { // display both dark and lit values
+        Serial.print(a0_dark);
+        Serial.print(comma);
+        Serial.print(a1_dark);
+        Serial.print(comma);
+        Serial.print(a2_dark);
+        Serial.print(comma);
+        Serial.print(a3_dark);
+        Serial.print(comma);
+        Serial.print(a4_dark);
+        Serial.print(comma);
+        Serial.print(a5_dark);
+        Serial.print(comma);
+        Serial.print(' ');
+        Serial.print(' ');
+        Serial.print(a0_lit);
+        Serial.print(comma);
+        Serial.print(a1_lit);
+        Serial.print(comma);
+        Serial.print(a2_lit);
+        Serial.print(comma);
+        Serial.print(a3_lit);
+        Serial.print(comma);
+        Serial.print(a4_lit);
+        Serial.print(comma);
+        Serial.print(a5_lit);
+    }
+    Serial.println();
 }

--- a/systick.cpp
+++ b/systick.cpp
@@ -7,7 +7,7 @@
        https://ukmars.org/
        https://github.com/ukmars/ukmarsbot
        https://github.com/robzed/pizero_for_ukmarsbot
-       
+
   MIT License
 
   Copyright (c) 2020-2021 Rob Probin & Peter Harrison
@@ -31,12 +31,12 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
   SOFTWARE.
 */
-#include <Arduino.h>
+#include "digitalWriteFast.h"
 #include "hardware_pins.h"
 #include "public.h"
-#include "digitalWriteFast.h"
-#include <wiring_private.h>
+#include <Arduino.h>
 #include <pins_arduino.h>
+#include <wiring_private.h>
 
 /***
  * Global variables
@@ -54,80 +54,87 @@ static uint8_t systick_phase = 0;
 
 /***
  * NOTE: Manual analogue conversions
- * All channels will be converted by systick nut conversions must be 
+ * All channels will be converted by systick nut conversions must be
  * performed manually. That is, AnalogueRead will block during a conversion
  * and that is not good
  */
 
 static uint8_t analog_reference = DEFAULT;
 
-void start_adc(uint8_t pin){
+void start_adc(uint8_t pin)
+{
 
-	if (pin >= 14) pin -= 14; // allow for channel or pin numbers
-	// set the analog reference (high two bits of ADMUX) and select the
-	// channel (low 4 bits).  this also sets ADLAR (left-adjust result)
-	// to 0 (the default).
+    if (pin >= 14)
+        pin -= 14; // allow for channel or pin numbers
+                   // set the analog reference (high two bits of ADMUX) and select the
+                   // channel (low 4 bits).  this also sets ADLAR (left-adjust result)
+                   // to 0 (the default).
 #if defined(ADMUX)
-	ADMUX = (analog_reference << 6) | (pin & 0x07);
+    ADMUX = (analog_reference << 6) | (pin & 0x07);
 #endif
-	// start the conversion
-	sbi(ADCSRA, ADSC);
+    // start the conversion
+    sbi(ADCSRA, ADSC);
 }
 
+int get_adc_result()
+{
+    // ADSC is cleared when the conversion finishes
+    // while (bit_is_set(ADCSRA, ADSC));
 
-int get_adc_result(){
-	// ADSC is cleared when the conversion finishes
-	// while (bit_is_set(ADCSRA, ADSC));
+    // we have to read ADCL first; doing so locks both ADCL
+    // and ADCH until ADCH is read.  reading ADCL second would
+    // cause the results of each conversion to be discarded,
+    // as ADCL and ADCH would be locked when it completed.
+    uint8_t low = ADCL;
+    uint8_t high = ADCH;
 
-	// we have to read ADCL first; doing so locks both ADCL
-	// and ADCH until ADCH is read.  reading ADCL second would
-	// cause the results of each conversion to be discarded,
-	// as ADCL and ADCH would be locked when it completed.
-	uint8_t low  = ADCL;
-	uint8_t high = ADCH;
-
-	// combine the two bytes
-	return (high << 8) | low;
+    // combine the two bytes
+    return (high << 8) | low;
 }
 
-void updateBatteryVolts() {
-  raw_BatteryVolts_adcValue = analogRead(BATTERY_VOLTS);
-  raw_BatteryVolts = raw_BatteryVolts_adcValue * (5.0f * batteryDividerRatio / 1023.0f);
+void updateBatteryVolts()
+{
+    raw_BatteryVolts_adcValue = analogRead(BATTERY_VOLTS);
+    raw_BatteryVolts = raw_BatteryVolts_adcValue * (5.0f * batteryDividerRatio / 1023.0f);
 }
 
 float get_BatteryVolts()
 {
-  return raw_BatteryVolts;
-  //return raw_BatteryVolts_adcValue * (5.0f * batteryDividerRatio / 1023.0f);
+    return raw_BatteryVolts;
+    //return raw_BatteryVolts_adcValue * (5.0f * batteryDividerRatio / 1023.0f);
 }
-
 
 /** @brief  Read the raw switch reading
  *  @return void
  */
-void updateFunctionSwitch() {
-  /**
+void updateFunctionSwitch()
+{
+    /**
    * Typical ADC values for all function switch settings
    */
-  Switch_ADC_value = analogRead(FUNCTION_PIN);
+    Switch_ADC_value = analogRead(FUNCTION_PIN);
 }
 
 /** @brief  Convert the switch ADC reading into a switch reading.
  *  @return void
  */
-int readFunctionSwitch() {
-  const int adcReading[] = {660, 647, 630, 614, 590, 570, 545, 522, 461,
-                            429, 385, 343, 271, 212, 128, 44,  0};
+int readFunctionSwitch()
+{
+    const int adcReading[] = {660, 647, 630, 614, 590, 570, 545, 522, 461,
+                              429, 385, 343, 271, 212, 128, 44, 0};
 
-  if(Switch_ADC_value > 1000){
-    return 16;
-  }
-  for (int i = 0; i < 16; i++) {
-    if (Switch_ADC_value > (adcReading[i] + adcReading[i + 1]) / 2) {
-      return i;
+    if (Switch_ADC_value > 1000)
+    {
+        return 16;
     }
-  }
-  return 15;   // should never get here... but if we do show 15
+    for (int i = 0; i < 16; i++)
+    {
+        if (Switch_ADC_value > (adcReading[i] + adcReading[i + 1]) / 2)
+        {
+            return i;
+        }
+    }
+    return 15; // should never get here... but if we do show 15
 }
 
 /***
@@ -135,26 +142,26 @@ int readFunctionSwitch() {
  * has all the answers but it is not easy to follow until you have some
  * experience. For now just use the code as it is.
  */
-void setupSystick() {
-  // set the mode for timer 2
-  bitClear(TCCR2A, WGM20);
-  bitSet(TCCR2A, WGM21);
-  bitClear(TCCR2B, WGM22);
+void setupSystick()
+{
+    // set the mode for timer 2
+    bitClear(TCCR2A, WGM20);
+    bitSet(TCCR2A, WGM21);
+    bitClear(TCCR2B, WGM22);
 
-  // set divisor to 32 => timer clock = 500kHz
-  bitClear(TCCR2B, CS22);
-  bitSet(TCCR2B, CS21);
-  bitSet(TCCR2B, CS20);
+    // set divisor to 32 => timer clock = 500kHz
+    bitClear(TCCR2B, CS22);
+    bitSet(TCCR2B, CS21);
+    bitSet(TCCR2B, CS20);
 
-  // set the timer frequency
-  OCR2A = 24;              // (16000000/32/20000)-1 = 24
-  bitSet(TIMSK2, OCIE2A);  // enable the timer interrupt
+    // set the timer frequency
+    OCR2A = 24;             // (16000000/32/20000)-1 = 24
+    bitSet(TIMSK2, OCIE2A); // enable the timer interrupt
 }
 
 unsigned long t_systick1 = 0;
 unsigned long t_systick2 = 0;
 unsigned long t_systick3 = 0;
-
 
 /***
  * This is the systick event - an ISR connected to Timer 2
@@ -162,113 +169,118 @@ unsigned long t_systick3 = 0;
  * is low.
  * There are 40 possible time-slots, or phases, if the systick
  * is intended to be synchronous with the main control loop
- * running every 2 milliseconds. 
- * Each tick is called every 50us so that an analogue conversion 
- * started in one phase will be completed ready for the next phase. 
+ * running every 2 milliseconds.
+ * Each tick is called every 50us so that an analogue conversion
+ * started in one phase will be completed ready for the next phase.
  * This technique avoids having the processor sitting idle
  * during conversions and while waiting for the sensors to respond.
  * So that high-speed encoder interrupts are not missed each phase
  * should ideally last no more than 10us.
- * 
- * The reason for this apparently arcane technique is that the 
- * ATMEGA328P does not have nested interrupts by default. At top speed, the 
+ *
+ * The reason for this apparently arcane technique is that the
+ * ATMEGA328P does not have nested interrupts by default. At top speed, the
  * encoders may generate interrupt at more than 20kHz and we cannot
  * afford to miss one. Also, received serial characters must be serviced
  * as they arrive or they will be lost. Having a single systick event
  * that does everything but takes many tens of microseconds risks
  * lost serial data and encoder pulses.
- *  
+ *
  * For testing, the built-in LED can be turned on at the start of the interrupt
  * and off again at the end. This can be used to measure system load.
- * Disable the feature if you want to use the built-in LED for some other 
+ * Disable the feature if you want to use the built-in LED for some other
  * purpose.
- * 
+ *
  */
-ISR(TIMER2_COMPA_vect) {
-  // digitalWriteFast(LED_BUILTIN, 1);
-  systick_phase++;
-  if (systick_phase >= 40) {
-    systick_phase = 0;
-  }
-  switch (systick_phase) {
+ISR(TIMER2_COMPA_vect)
+{
+    // digitalWriteFast(LED_BUILTIN, 1);
+    systick_phase++;
+    if (systick_phase >= 40)
+    {
+        systick_phase = 0;
+    }
+    switch (systick_phase)
+    {
     case 0:
-      // always start conversions as soon as  possible so they get a
-      // full 50us to convert
-      start_adc(BATTERY_VOLTS);
-      delayMicroseconds(40);  // just a long marker for the oscilloscope.
-      break;
+        // always start conversions as soon as  possible so they get a
+        // full 50us to convert
+        start_adc(BATTERY_VOLTS);
+        delayMicroseconds(40); // just a long marker for the oscilloscope.
+        break;
     case 1:
-      raw_BatteryVolts_adcValue = get_adc_result();
-      start_adc(FUNCTION_PIN);
-      // TODO find a magic voltage divider ratio that makes this a single multiply for millivolts
-      raw_BatteryVolts = (raw_BatteryVolts_adcValue * 2 * 5) / 1024;
-      break;
+        raw_BatteryVolts_adcValue = get_adc_result();
+        start_adc(FUNCTION_PIN);
+        // TODO find a magic voltage divider ratio that makes this a single multiply for millivolts
+        raw_BatteryVolts = (raw_BatteryVolts_adcValue * 2 * 5) / 1024;
+        break;
     case 2:
-      Switch_ADC_value = get_adc_result();
-      start_adc(A0);
-      break;
+        Switch_ADC_value = get_adc_result();
+        start_adc(A0);
+        break;
     case 3:
-      gSensorA0_dark = get_adc_result();
-      start_adc(A1);
-      break;
+        gSensorA0_dark = get_adc_result();
+        start_adc(A1);
+        break;
     case 4:
-      gSensorA1_dark = get_adc_result();
-      start_adc(A2);
-      break;
+        gSensorA1_dark = get_adc_result();
+        start_adc(A2);
+        break;
     case 5:
-      gSensorA2_dark = get_adc_result();
-      start_adc(A3);
-      break;
+        gSensorA2_dark = get_adc_result();
+        start_adc(A3);
+        break;
     case 6:
-      gSensorA3_dark = get_adc_result();
-      start_adc(A4);
-      break;
+        gSensorA3_dark = get_adc_result();
+        start_adc(A4);
+        break;
     case 7:
-      gSensorA4_dark = get_adc_result();
-      start_adc(A5);
-      break;
+        gSensorA4_dark = get_adc_result();
+        start_adc(A5);
+        break;
     case 8:
-      gSensorA5_dark = get_adc_result();
-      // got all the dark ones so light them up
-      if (emitter_on) {
-        digitalWriteFast(EMITTER, 1);
-      }
-      // wait at least one cycle for the detectors to respond
-      break;
+        gSensorA5_dark = get_adc_result();
+        // got all the dark ones so light them up
+        if (emitter_on)
+        {
+            digitalWriteFast(EMITTER, 1);
+        }
+        // wait at least one cycle for the detectors to respond
+        break;
     case 9:
-      start_adc(A0);
-      break;
+        start_adc(A0);
+        break;
     case 10:
-      gSensorA0_light = get_adc_result();
-      start_adc(A1);
-      break;
+        gSensorA0_light = get_adc_result();
+        start_adc(A1);
+        break;
     case 11:
-      gSensorA1_light = get_adc_result();
-      start_adc(A2);
-      break;
+        gSensorA1_light = get_adc_result();
+        start_adc(A2);
+        break;
     case 12:
-      gSensorA2_light = get_adc_result();
-      start_adc(A3);
-      break;
+        gSensorA2_light = get_adc_result();
+        start_adc(A3);
+        break;
     case 13:
-      gSensorA3_light = get_adc_result();
-      start_adc(A4);
-      break;
+        gSensorA3_light = get_adc_result();
+        start_adc(A4);
+        break;
     case 14:
-      gSensorA4_light = get_adc_result();
-      start_adc(A5);
-      break;
+        gSensorA4_light = get_adc_result();
+        start_adc(A5);
+        break;
     case 15:
-      gSensorA5_light = get_adc_result();
-      if (emitter_on) {
-        digitalWriteFast(EMITTER, 0);
-      }
-      break;
+        gSensorA5_light = get_adc_result();
+        if (emitter_on)
+        {
+            digitalWriteFast(EMITTER, 0);
+        }
+        break;
     default:
-      break;
-  }
-  // digitalWriteFast(LED_BUILTIN, 0);
-  /***
+        break;
+    }
+    // digitalWriteFast(LED_BUILTIN, 0);
+    /***
    * Speed control may now need to happen either in short sections here
    * or at the top level of the code. A flag, set in one phase
    * of systick could tell the higher level code that it is time to

--- a/ukmarsey.ino
+++ b/ukmarsey.ino
@@ -7,7 +7,7 @@
        https://ukmars.org/
        https://github.com/ukmars/ukmarsbot
        https://github.com/robzed/pizero_for_ukmarsbot
-       
+
   MIT License
 
   Copyright (c) 2020-2021 Rob Probin & Peter Harrison
@@ -32,25 +32,24 @@
   SOFTWARE.
 */
 
-
-#include <Arduino.h>
 #include "public.h"
+#include <Arduino.h>
 
 uint8_t PoR_status = 0;
-void setup() {
-  PoR_status = MCUSR;   // is this erased by bootloader?
-  MCUSR = 0;
-  pinMode(LED_BUILTIN, OUTPUT);
-  Serial.begin(115200);
-  Serial.println(F("Hello from ukmarsey"));
-  setupSystick();
-  //wall_sensors_setup();
-  sensors_control_setup();
-  setupEncoders();
-  motorSetup();
-  init_stored_parameters();
+void setup()
+{
+    PoR_status = MCUSR; // is this erased by bootloader?
+    MCUSR = 0;
+    pinMode(LED_BUILTIN, OUTPUT);
+    Serial.begin(115200);
+    Serial.println(F("Hello from ukmarsey"));
+    setupSystick();
+    //wall_sensors_setup();
+    sensors_control_setup();
+    setupEncoders();
+    motorSetup();
+    init_stored_parameters();
 }
-
 
 //extern unsigned long t_systick1;
 //extern unsigned long t_systick2;
@@ -58,9 +57,10 @@ void setup() {
 
 //unsigned int next_time = 0;
 
-void loop() {
+void loop()
+{
 
-  /*
+    /*
     if(millis() >= next_time)
     {
       delay(100);
@@ -85,6 +85,5 @@ void loop() {
     }
   */
 
-
-  interpreter();
+    interpreter();
 }

--- a/wall-sensors.cpp
+++ b/wall-sensors.cpp
@@ -7,7 +7,7 @@
        https://ukmars.org/
        https://github.com/ukmars/ukmarsbot
        https://github.com/robzed/pizero_for_ukmarsbot
-       
+
   MIT License
 
   Copyright (c) 2020-2021 Rob Probin & Peter Harrison
@@ -31,10 +31,10 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
   SOFTWARE.
 */
-#include <Arduino.h>
 #include "hardware_pins.h"
+#include <Arduino.h>
 
-#if 0     // disabled for now - replace with generic sensor system (under development).
+#if 0 // disabled for now - replace with generic sensor system (under development).
 #define ENABLE_SENSOR_LED_OUTPUT 0
 
 /***


### PR DESCRIPTION
clang-format is widely available on any system. It is is also built in to some IDEs like VSCode when using the C/C++ extensions.

Indent widths and styles attract almost religious argument but consistency is more important than actual detail.
Here, the Allman style was already predominant in the existing sources and so it was chosen. The other most common style is probably K&R.

http://www.terminally-incoherent.com/blog/2009/04/10/the-only-correct-indent-style/

If files are consistently formatted by all contributors, git commits are more focussed on functional rather than stylistic changes.

VSCode will use the .clang-format file in the code directory. clang-format will also, by default, use the definitions in the .clang-format file. It seems sensible to retain the definitions file as part of the repo.

From the command line use this to format all of the sources in-place if your editor/IDE does not provide a way to do it:
    
    clang-format -i *.cpp *.h *.ino
