### PR TITLE
Add a Simple Stopwatch

### DIFF
--- a/digitalWriteFast.h
+++ b/digitalWriteFast.h
@@ -4,6 +4,7 @@
   based on http://code.google.com/p/digitalwritefast
  */
 
+#include <Arduino.h>
 #ifndef __digitalWriteFast_h_
 #define __digitalWriteFast_h_ 1
 

--- a/hardware_pins.h
+++ b/hardware_pins.h
@@ -3,6 +3,9 @@
 /**
  * Hardware pin defines
  */
+
+#include <Arduino.h>
+
 #define BOARD UKMARSBOT_V1
 const int ENCODER_LEFT_CLK = 2;
 const int ENCODER_RIGHT_CLK = 3;

--- a/stopwatch.h
+++ b/stopwatch.h
@@ -1,0 +1,75 @@
+/*
+ * Stopwatch class - provides basic microsecond level timing.
+
+   ukmarsey is a machine and human command-based Robot Low-level I/O platform initially targetting UKMARSBot
+   For more information see:
+       https://github.com/robzed/ukmarsey
+       https://ukmars.org/
+       https://github.com/ukmars/ukmarsbot
+       https://github.com/robzed/pizero_for_ukmarsbot
+
+  MIT License
+
+  Copyright (c) 2020-2021 Rob Probin & Peter Harrison
+  Copyright (c) 2019-2021 UK Micromouse and Robotics Society
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+
+#ifndef _STOPWATCH_H
+#define _STOPWATCH_H
+
+#include <Arduino.h>
+
+class Stopwatch
+{
+
+public:
+    Stopwatch()
+    {
+        start();
+    };
+
+    void start()
+    {
+        start_time = micros();
+        stop_time = start_time;
+    };
+
+    void stop()
+    {
+        stop_time = micros();
+    };
+
+    uint32_t split()
+    {
+        return micros() - start_time;
+    }
+
+    uint32_t elapsed_time() const
+    {
+        return stop_time - start_time;
+    };
+
+private:
+    uint32_t start_time;
+    uint32_t stop_time;
+};
+
+#endif


### PR DESCRIPTION
Since we are timing code quite often, I created a rudimentary Stopwatch class to record times in microseconds.

Call overhead is a few microseconds and dominated in any case by the systick interrupt run time.

If used inside a function, it takes just 8 bytes on the stack and no global memory. Use like:

````
  :
  Stopwatch sw;
  // code to test
  sw.stop();
  :
  Serial.print(sw.elapsed_time());
  :
````