### PR TITLE
New settings methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # UKMARSEY Command Language
 
-This is a real-time command language for low level I/O micros of mobile robots, and first with the UKMARSBOT Robot. 
+This is a real-time command language for low level I/O micros of mobile robots, and first with the UKMARSBOT Robot.
 
-The commands are terse but intended to be entered either by human via a 
-terminal or via machine, e.g. a Pi Zero. It's intention is to allow real-time 
+The commands are terse but intended to be entered either by human via a
+terminal or via machine, e.g. a Pi Zero. It's intention is to allow real-time
 command loops of low level operations, or high-level control for less experienced users.
 
 NOTE: Originally this project was intended as a wall follower for the UKMARSBOT robot, but it only got as far as a hardware test command line via a simple command line interpreter before it was repurposed.
@@ -21,7 +21,7 @@ This project is licensed under the MIT license.
 
 Loads into Arduino via serial lead from the Arduino IDE. You can issue commands to get the robot to do things.
 
-As well as directly commanding the robot over the serial port, it's designed to be controlled from a host CPU which can be anything 
+As well as directly commanding the robot over the serial port, it's designed to be controlled from a host CPU which can be anything
 but we've been using it with the Raspberry Pi.
 
 There is some more information about development environments in [Code Development](Documentation/code_development.md).
@@ -54,7 +54,7 @@ Once connected you should get a prompt like on reset:
 
 No spaces, tabs or other control characters (below value 32) are allowed in commands, except for those mentioned below in 'Special Control Characters' below, and their use is undefined and may change in future versions of the interpreter. (Technically UTF-8 characters are ok, but none are currently used in commands).
 
-All serial commands are case sensitive. Each command needs to have a LF (10, 0x0D) at the end of it. 
+All serial commands are case sensitive. Each command needs to have a LF (10, 0x0D) at the end of it.
 
 Values are in decimal, but if the value is out of range then interpreter will either issue an error, ignore extra values or interpret this in an undefined way. This last two options are considered undefined operation - and future changes of the interpreter might change the behaviour. Examples are D11= (no value), D11=2 (out of range setting of an I/O port, might throw an error.), D11=100 (out of range, might ignore 00) or D1=-3 (unexpected minus, probably error).
 
@@ -62,9 +62,9 @@ Any commands that return values is done on a seperate line per command. The ends
 
 ## Special Control Characters
 
-* Control-X (0x18) - Soft-Reset - same as Control-C, but stops motors, and any active commands. (Same as 'x' command). 
+* Control-X (0x18) - Soft-Reset - same as Control-C, but stops motors, and any active commands. (Same as 'x' command).
 * Control-C (0x03) - Abort entry of line. NOTICE: Character subsequent to this character will be treated as the start of a new line.
-* Line Feed (LF, 0x10) - Finish line entry and send to the interpreter. 
+* Line Feed (LF, 0x10) - Finish line entry and send to the interpreter.
 * Carriage Return (CR, 0x13) - Ignored by interpreter.
 * Backspace (0x08) - Removes one character from input buffer, assuming input buffer has any characters in. Generates "\x08 \x08" which should step back, erase, then step back. However on some serial terminal emulators this might need to be enabled (e.g. on CoolTerm this option is 'Handle BS and Del Characters').
 
@@ -77,7 +77,7 @@ Note: 'x' command stops the motors in the case of runaway, but requires a newlin
 
 | Cmd | Action    |
 |:---:|-----------|
-| ^ | reset state - writes RST in reply. | 
+| ^ | reset state - writes RST in reply. |
 | ^^ | processor reset |
 | v | show version |
 | V | Verbose error code, 2=extra verbose (default), 1=verbose, 0=numeric - see 'Interpreter errors'.  |
@@ -107,7 +107,7 @@ Examples:
     T-20    Move backward at -20 millimeters per second
     T,11    Rotate anticlockwise at 11 degrees per second
     T,-45   Rotate clockwise at 45 degrees per second
-    T20,11  Move forward at 20 millimeters per second while rotating anticlockwise at 
+    T20,11  Move forward at 20 millimeters per second while rotating anticlockwise at
     T0,0    Stop (both speed and rotation)
     T       Set speed to zero, leave rotation the same value
     T,      Set rotation to zero, leave speed the same value
@@ -120,7 +120,7 @@ Examples:
 |  D  | Dp or Dp=n | Set or read digital pin |
 |  A  | Aa or Ap=n | Read analogue pin, or write PWM pin |
 |  M  | Mm=p       | Motor control, using PWM value. 1 = left motor, 0 or 2 = right motor. PWM value -255 to 255, with 0 as stop. |
-|  N  | Nm,n       | Dual motor control specifying a battery voltage | 
+|  N  | Nm,n       | Dual motor control specifying a battery voltage |
 |  P  | Pp=d       | PinMode - Set up GPIO pins; p is pin, d is I(input) or O(output) or U(Pull Up Input)  |
 
 Regarding analogue readings, (A command), these are read off interrupts, so can be up to 2ms old.
@@ -158,12 +158,12 @@ Output a motor PWM duty cycle from the range 0..255.
     M2=-128         Half PWM backwards, right motor
     M0=128          Right motor
 
-N command also controls the motors, however it's referenced to battery which means we can avoid differnt speeds as the battery discharges - and instead specify voltages rather than PWM (which is in fact a proportion of the current battery voltage). The general format is 'Nf,g' where f and g are signed floats representing voltage levels, negative backwards, positive forward. 
+N command also controls the motors, however it's referenced to battery which means we can avoid differnt speeds as the battery discharges - and instead specify voltages rather than PWM (which is in fact a proportion of the current battery voltage). The general format is 'Nf,g' where f and g are signed floats representing voltage levels, negative backwards, positive forward.
 
     N3.5,-3.5       Left motor 3.5 volts, right motor backwards 3.5 volts
     N0,0            Stop both motors
 
-The advantage of this command is that it will go the same speed regardless of battery level, assuming you keep values to the range underneath the minimum battery voltage expected. 
+The advantage of this command is that it will go the same speed regardless of battery level, assuming you keep values to the range underneath the minimum battery voltage expected.
 
 The Pin mode commands allows the user to configure pins.
 
@@ -196,13 +196,13 @@ Reading an encoder counter might be more involved. It is the total so far and th
 | Cz | Same as C, but also zeros encoders immediately after reading |
 | Ch | Same as C, but values in Hex |
 | ChZ| Same as Ch, but also zeros encoders immediately after reading |
-| z | zero wheel encoder counters. No return. | 
+| z | zero wheel encoder counters. No return. |
 | ea | print wheel current info (all) - Format 'encoder-sum,distance,encoder-difference,angle' |
 | e  | Old command for 'ea' command, still supported for backward compatability |
 | er | print wheel current info (raw format) - Format 'encoder-sum,encoder-difference'|
 | eu | print wheel current info (unit format) - Format 'distance,angle' where distance is mm, angle is degrees |
 | es | print speed (mm/s) and rotation speed (degrees/s)
-| r | print encoder setup - Format 'mm-per-count,degrees-per-count' | 
+| r | print encoder setup - Format 'mm-per-count,degrees-per-count' |
 
 NOTE: 'r' command allows decoding 'er' into distances/angles on the host, rather than taking time to print floating values.
 
@@ -229,9 +229,9 @@ Examples:
 
 ### Sensor Processing commands
 
-It's sometimes necessary, with Infra-red sensors, to read the IR sensor 'dark', turn on IR illumination, take another IR sensor reading ('light') then turn the IR illumination off. 
+It's sometimes necessary, with Infra-red sensors, to read the IR sensor 'dark', turn on IR illumination, take another IR sensor reading ('light') then turn the IR illumination off.
 
-These commands provide the ability to specify up to three output ports for IR illumination, and read up to size sensors. 
+These commands provide the ability to specify up to three output ports for IR illumination, and read up to size sensors.
 
 By default this is set up to read A0, A1, A2, A3 as sensors and use D12 to turn on the IR illumination with a logic 1 , which will work for the standard line and wall followers of the UKMARSBot (although the wall follower doesn't use A3).
 
@@ -274,66 +274,28 @@ Examples of Emitter control:
 
 ### Parameter Commands
 
-Parameters select specific characteristics of high level commands. They are stored in EEPROM so are preserved on power off, especially for human users. 
+Parameters select specific characteristics of high level commands. They are stored in EEPROM so are preserved on power off, especially for human users. Parameters hold values such as the current tuning constants for controllers.
+
+There are three sets of parameters available stored in different locations:
+
+ * FLASH - the defaults hard coded into the firmware when it was build. They cannot be changed by the code.
+ * RAM - the current working versions. These are the settings used by the robot when running and will be lost after a reset.
+ * EEPROM - Held in non-volatile memory, these will survive reset and will normally be read into the RAM settings at reset. Users must manually store settings to EEPROM if they are to be retained over a reset.
 
 | Cmd | Action    |
-|:---:|-----------|
-| $*n* | Read parameter *n* |    
+|:---|-----------|
+| $*n*  | Read parameter *n* |
 | $*n*=*f* | Write parameter *n* with value *f*. E.g. $0=1.1 |
-| $a   | Read all floating parameters seperate lines per parameter. |
-| $b   | Read all boolean (bit) parameters, as 32 seperate lines. |
-| $d   | Default all parameters. |
-
-NOTE: $a and $b will incur serial buffering and block until complete 
-
-Currently all parameters are floating point values. 
-
-A List of specific usage of each parameters is here.
-
-| Param | Action    |
-|:-----:|-----------|
-| 0 | *Undefined* |
-| 1 | *Undefined*  |
-| 2 | *Undefined*  |
-| 3 | *Undefined*  |
-| 4 | *Undefined*  |
-| 5 | *Undefined*  |
-| 6 | *Undefined*  |
-| 7 | *Undefined*  |
-| 8 | *Undefined*  |
-| 9 | *Undefined*  |
-| 10 | *Undefined*  |
-| 11 | *Undefined*  |
-| 12 | *Undefined*  |
-| 13 | *Undefined*  |
-| 14 | *Undefined*  |
-| 15 | *Undefined*  |
-
-There are also 32 boolean ('bit') parameters. The first 16 are listed here. Current all are undefined.
-
-| Param | Action    |
-|:-----:|-----------|
-| 100 | *Undefined* |
-| 101 | *Undefined*  |
-| 102 | *Undefined*  |
-| 103 | *Undefined*  |
-| 104 | *Undefined*  |
-| 105 | *Undefined*  |
-| 106 | *Undefined*  |
-| 107 | *Undefined*  |
-| 108 | *Undefined*  |
-| 109 | *Undefined*  |
-| 110 | *Undefined*  |
-| 111 | *Undefined*  |
-| 112 | *Undefined*  |
-| 113 | *Undefined*  |
-| 114 | *Undefined*  |
-| 115 | *Undefined*  |
+| $$   | display values of all settings in RAM|
+| $?   | Display a detailed list of the working settings as a C declaration |
+| $@   | Load all saved settings from EEPROM |
+| $!   | Store current working settings to EEPROM |
+| $#   | Restore defaults hard-coded in firmware |
 
 
 ### High Level I/O Control
- 
-(to be added) 
+
+(to be added)
 
 ### General Commands
 
@@ -342,11 +304,11 @@ There are also 32 boolean ('bit') parameters. The first 16 are listed here. Curr
 | l |  (lower case L) Led on/off, l0 = led off, l1 = led on. (Short version of D13=x) |
 | ? | just prints 'OK' |
 | h | just prints 'OK' |
-| s | shows the state of the switches. Returns a single number. NOTE: the Button is '16', and overrides the 4 switches | 
+| s | shows the state of the switches. Returns a single number. NOTE: the Button is '16', and overrides the 4 switches |
 | b | shows the voltage of the battery. Example return '7.421' |
 | bi | Shows the voltage of the battery in millivolts. Example: '7421' |
 | bh | Shows the voltage of the battery in millivolts in hex format |
-| m | motor tests (see below) | 
+| m | motor tests (see below) |
 | x | Motor stop (no parameters, no return.) - and cancels any actions |
 
 
@@ -377,14 +339,14 @@ m = motor tests, runs for 2 seconds or until button is pressed.
 
 ## Resetting and getting the Pi in sync with the Arduino.
 
-Send Control-C (or Control-X) followed by ^ repeatedly with a 20ms gap until you receive a RST message. Then try ? and v looking at the responses. If they don't succeeed, then repeat the entire sequence. 
+Send Control-C (or Control-X) followed by ^ repeatedly with a 20ms gap until you receive a RST message. Then try ? and v looking at the responses. If they don't succeeed, then repeat the entire sequence.
 
-This is under review. 
+This is under review.
 
 
 ## Interpreter Errors
 
-Interpreter error text strings (verbose on) are not defined to be stable across versions. Numeric error codes (verbose off) will be stable across releases as far as possible. 
+Interpreter error text strings (verbose on) are not defined to be stable across versions. Numeric error codes (verbose off) will be stable across releases as far as possible.
 
 NOTE: All error messages (both verbose text and numeric are preceeded by '@Error:' as the first characters on the line, except for verbose error for OK, which appears simply as 'OK' on the line.
 
@@ -453,19 +415,19 @@ https://github.com/micromouseonline/ukmarsbot-line-follower-basic
 
 It bares some resemblance in some places to G-code (and implementations like grbl), but does not attempt to maintain any G-code compatability, since really G-code is targetted at CNC not really at self-moving small robots.
 
-Since this runs on an ATMEG328P Arduino Nano, there is not much Flash or RAM, so things like help and extended error messages have been minimised. 
+Since this runs on an ATMEG328P Arduino Nano, there is not much Flash or RAM, so things like help and extended error messages have been minimised.
 
 We aim to have shortened the amount of bytes requiring to be transmitted in order to maximise the bandwidth across the serial link, while still allowing for easy human entry via a text terminal.
 
 
 # Dev Notes
 
-## ADC 
+## ADC
 There are three subsystems running all the time currently on the system tick interrupt that runs every 2ms: battery reading, function switch reading and update sensors control. The analogue command (e.g. A0) uses these subsystems to read the ADCs (partially to avoid conflicts since there is only one ADC unit).
 
 ## Serial Buffering
 
-The Arduino Nano has a 64 byte input buffer and a 64 byte output buffer. Transmission to and from the Arduino needs to be carefully designed not to overrun these buffers. 
+The Arduino Nano has a 64 byte input buffer and a 64 byte output buffer. Transmission to and from the Arduino needs to be carefully designed not to overrun these buffers.
 
 If you overrun the 64 byte output buffer the print commands will start waiting inside the Arduino Nano (the commands will take longer to complete). The could cause several affects - once of which could potentially be commands stacking up in the input buffer. It only requires, for instance perhaps three 'Sr' commands to cause the output buffer to be filled.
 
@@ -481,6 +443,6 @@ One such baud rate table for the AVR on the Arduino Nano includes: https://trols
 
 Remeber to add on the error rate of the other side as well - whehter that be a Rasberry Pi, USB-Serial converter, or other serial port. Sometimes you can get lucky. If they are both, say +3% of the target, then the baud rates will match. But a -2.5% on one end, and a +2.5% on the other end gives 5% error, and this will cause problems. (Although errors rates up to 5% would theoretically work before it meets an edge, the reality of sampling mechanisms, slew rate and other factors means that realistic error rates are well under half of this.)
 
-Sometimes these cannot be simply looked up from microcontroller or microprocessor data sheets - crystals tend to be accurate, but devices with resonators or internal RC oscillators tend to have large tolerance between devices themselves - and this needs to be taken into account. 
+Sometimes these cannot be simply looked up from microcontroller or microprocessor data sheets - crystals tend to be accurate, but devices with resonators or internal RC oscillators tend to have large tolerance between devices themselves - and this needs to be taken into account.
 
 

--- a/interpreter.cpp
+++ b/interpreter.cpp
@@ -164,11 +164,6 @@ int8_t reset_state()
         void (*resetFunc)(void) = 0; // declare reset fuction at address 0
         resetFunc();
     }
-    else if (function == '?')
-    {
-        extern uint8_t PoR_status;
-        Serial.println(PoR_status);
-    }
     else
     {
         // We should reset all state here. At the moment there isn't any.

--- a/interpreter.cpp
+++ b/interpreter.cpp
@@ -830,7 +830,6 @@ int8_t stop_motors_and_everything_command()
     rot_set_speed = 0;
 
     // add action stop here as well
-
     return T_OK;
 }
 

--- a/interpreter.cpp
+++ b/interpreter.cpp
@@ -884,7 +884,7 @@ int8_t set_target_speed()
     int target_fwd_speed_in_mm_per_second;
     int target_rotational_speed_in_degrees_per_second;
 
-    if(inputString[1] == ',')
+    if (inputString[1] == ',')
     {
         // rotation speed only
         target_rotational_speed_in_degrees_per_second = decode_input_value_signed(2);
@@ -910,7 +910,6 @@ int8_t set_target_speed()
     enable_controllers();
     return T_OK;
 }
-
 
 int execute_settings_command(char *line)
 {
@@ -994,7 +993,6 @@ int8_t system_command()
 {
     return execute_settings_command(inputString);
 }
-
 
 int8_t not_implemented()
 {

--- a/interpreter.cpp
+++ b/interpreter.cpp
@@ -36,132 +36,20 @@
 #include "interpreter.h"
 #include "digitalWriteFast.h"
 #include "public.h"
+#include "settings.h"
 #include "switches.h"
 #include "tests.h"
 #include <Arduino.h>
-#include <EEPROM.h>
+
 /*
  * Small command line interpreter
  */
 
-#define MAX_INPUT_SIZE 14
-static char inputString[MAX_INPUT_SIZE]; // a String to hold incoming data
-static int inputIndex = 0;               // where we are on the input
+// TODO: have CLI treat '#' as a comment character and drop remaining line
+
+char inputString[MAX_INPUT_SIZE]; // a String to hold incoming data
+int inputIndex = 0;               // where we are on the input
 static bool interpreter_echo = true;
-
-//
-// There are (NUM_STORED_PARAMS+2) * 4 bytes stored in EEPROM. NOTE: The last one is a magic number to detect an uninitialised EEPROM.
-//
-#define NUM_STORED_PARAMS 16
-
-float stored_params[NUM_STORED_PARAMS];
-static const float stored_parameters_default_values[NUM_STORED_PARAMS] = {
-
-    // Index: Usage
-    0.0F, //  0: undefined
-    0.0F, //  1: undefined
-    0.0F, //  2: undefined
-    0.0F, //  3: undefined
-
-    0.0F, //  4: undefined
-    0.0F, //  5: undefined
-    0.0F, //  6: undefined
-    0.0F, //  7: undefined
-
-    0.0F, //  8: undefined
-    0.0F, //  9: undefined
-    0.0F, // 10: undefined
-    0.0F, // 11: undefined
-
-    0.0F, // 12: undefined
-    0.0F, // 13: undefined
-    0.0F, // 14: undefined
-    0.0F, // 15: undefined
-
-};
-
-#define NUMBER_OF_BITFIELD_STORED_PARAMS 32
-static const uint32_t bitfield_default_values =
-    // Default 0UL/1UL  Index: Usage
-    (0UL << 31) + // 131: undefined
-    (0UL << 30) + // 130: undefined
-    (0UL << 29) + // 129: undefined
-    (0UL << 28) + // 128: undefined
-    (0UL << 27) + // 127: undefined
-    (0UL << 26) + // 126: undefined
-    (0UL << 25) + // 125: undefined
-    (0UL << 24) + // 124: undefined
-
-    (0UL << 23) + // 123: undefined
-    (0UL << 22) + // 122: undefined
-    (0UL << 21) + // 121: undefined
-    (0UL << 20) + // 120: undefined
-    (0UL << 19) + // 119: undefined
-    (0UL << 18) + // 118: undefined
-    (0UL << 17) + // 117: undefined
-    (0UL << 16) + // 116: undefined
-
-    (0UL << 15) + // 115: undefined
-    (0UL << 14) + // 114: undefined
-    (0UL << 13) + // 113: undefined
-    (0UL << 12) + // 112: undefined
-    (0UL << 11) + // 111: undefined
-    (0UL << 10) + // 110: undefined
-    (0UL << 9) +  // 109: undefined
-    (0UL << 8) +  // 108: undefined
-
-    (0UL << 7) + // 107: undefined
-    (0UL << 6) + // 106: undefined
-    (0UL << 5) + // 105: undefined
-    (0UL << 4) + // 104: undefined
-    (0UL << 3) + // 103: undefined
-    (0UL << 2) + // 102: undefined
-    (0UL << 1) + // 101: undefined
-    (0UL);       // 100: undefined
-//
-// actual data storage
-//
-uint32_t bitfield_stored_params = bitfield_default_values;
-
-// Addresses
-#define BITFIELD_ADDRESS ((NUM_STORED_PARAMS + 1) * 4)
-#define MAGIC_ADDRESS (BITFIELD_ADDRESS + sizeof(bitfield_stored_params))
-
-//
-// Version number for parameter configuration in EEPROM
-//
-// If the parameter configuration in EEPROM changes, increase this number
-// and new versions will get a clean set of defaults.
-#define PARAMETER_EEPROM_VERSION 1
-
-// Magic to detect uninitialised space
-#define MAGIC_NUMBER ((0x00CAFE00) ^ (PARAMETER_EEPROM_VERSION))
-
-/** @brief  Access a stored parameter
- *  @param  Index of parameter
- *  @return stored_param, or 0 if that parameter doesn't exist.
- */
-float get_float_param(int param_index)
-{
-    if (param_index < 0 or param_index > NUM_STORED_PARAMS)
-    {
-        return 0;
-    }
-    return stored_params[param_index];
-}
-
-/** @brief  Access a stored bool parameter
- *  @param  Index of parameter
- *  @return stored_param, or false if that parameter doesn't exist.
- */
-bool get_bool_param(int param_index)
-{
-    if (param_index < 100 or param_index > NUMBER_OF_BITFIELD_STORED_PARAMS)
-    {
-        return false;
-    }
-    return bitfield_stored_params & (1 << (param_index - 100));
-}
 
 // ------------------------------------------
 // These are the types
@@ -758,76 +646,34 @@ int8_t motor_control_dual_voltage()
     }
     return T_OK;
 }
-
+/*----------------------------------------------------------------*/
 /** @brief Reads and writes stored parameters
  *  @return Void.
  */
 int8_t stored_parameter_control()
 {
     int param_number = decode_input_value(1);
-    if (param_number >= 0 and param_number < NUM_STORED_PARAMS)
+    if (param_number >= 0 and param_number < get_settings_count())
     {
         if (inputString[inputIndex] == '=')
         {
-            // write param
-            //
             float param = decode_input_value_float(inputIndex + 1);
-            stored_params[param_number] = param;
-            EEPROM.put(param_number * 4, param);
+            write_setting(param_number, param);
         }
         else // read param
         {
-            Serial.println(stored_params[param_number], floating_decimal_places);
-        }
-    }
-    else if (param_number >= 100 and param_number < (100 + NUMBER_OF_BITFIELD_STORED_PARAMS))
-    {
-        uint8_t shift = param_number - 100;
-        if (inputString[inputIndex] == '=')
-        {
-            uint32_t mask = 1UL << shift;
-            uint32_t bit_value = decode_input_value(inputIndex + 1);
-            if (bit_value)
-            {
-                bitfield_stored_params |= mask;
-            }
-            else
-            {
-                bitfield_stored_params &= ~mask;
-            }
-            EEPROM.put(BITFIELD_ADDRESS, bitfield_stored_params);
-        }
-        else
-        {
-            Serial.println((bitfield_stored_params >> shift) & 1);
+            print_setting(param_number, floating_decimal_places);
         }
     }
     else
     {
         if (inputString[1] == 'a')
         {
-            for (int i = 0; i < NUM_STORED_PARAMS; i++)
-            {
-                Serial.println(stored_params[i], floating_decimal_places);
-            }
-        }
-        else if (inputString[1] == 'b')
-        {
-            for (int i = 0; i < NUMBER_OF_BITFIELD_STORED_PARAMS; i++)
-            {
-                Serial.println((bitfield_stored_params & (1UL << i)) ? 1 : 0);
-            }
+            dump_settings(floating_decimal_places);
         }
         else if (inputString[1] == 'd')
         {
-            const float *p = stored_parameters_default_values;
-            for (int i = 0; i < NUM_STORED_PARAMS; i++)
-            {
-                EEPROM.put(i * 4, *p);
-                stored_params[i] = *p++;
-            }
-            EEPROM.put(BITFIELD_ADDRESS, bitfield_default_values);
-            bitfield_stored_params = bitfield_default_values;
+            restore_default_settings();
         }
         else
         {
@@ -842,31 +688,10 @@ int8_t stored_parameter_control()
  */
 void init_stored_parameters()
 {
-    uint32_t magic = 0;
-    EEPROM.get(MAGIC_ADDRESS, magic);
-    if (magic != MAGIC_NUMBER)
-    {
-        Serial.println("@Defaulting Params");
-        // default values here
-        const float *p = stored_parameters_default_values;
-        for (int i = 0; i < NUM_STORED_PARAMS; i++)
-        {
-            // we use write here, not update
-            EEPROM.put(i * 4, *p++);
-        }
-        EEPROM.put(BITFIELD_ADDRESS, bitfield_default_values);
-        // finally write magic back
-        EEPROM.put(MAGIC_ADDRESS, MAGIC_NUMBER);
-    }
-
-    for (int i = 0; i < NUM_STORED_PARAMS; i++)
-    {
-        float f;
-        EEPROM.get(i * 4, f);
-        stored_params[i] = f;
-    }
-    EEPROM.get(BITFIELD_ADDRESS, bitfield_stored_params);
+    load_settings_from_eeprom();
 }
+
+/*----------------------------------------------------------------*/
 
 /** @brief Turns command line interpreter verbose error messages on and off
  *  @return Void.

--- a/interpreter.cpp
+++ b/interpreter.cpp
@@ -938,12 +938,7 @@ int execute_settings_command(char *line)
                 // list the settings names and types?
                 // or send them as a C declaration?
                 // or a JSON object ...
-
-                for (int i = 0; i < get_settings_count(); i++)
-                {
-                    print_setting_details(i);
-                    Serial.println(';');
-                }
+                dump_settings_detail();
                 return T_OK;
                 break;
         }

--- a/interpreter.cpp
+++ b/interpreter.cpp
@@ -1259,7 +1259,7 @@ void parse_cmd()
 #define CTRL_C 0x03
 #define BACKSPACE 0x08
 #define CTRL_X 0x18
-static char last_NL = 0;        // tracks NL changes
+static char last_NL = 0; // tracks NL changes
 
 /** @brief  Command line interpreter.
  *  @return Void.

--- a/interpreter.h
+++ b/interpreter.h
@@ -49,7 +49,9 @@ enum
     T_UNKNOWN_COMMAND = 4,
     T_UNEXPECTED_TOKEN = 5
 };
-
+#define MAX_INPUT_SIZE 14
+extern char inputString[MAX_INPUT_SIZE]; // a String to hold incoming data
+extern int inputIndex;                   // where we are on the input
 void interpreter();
 void init_stored_parameters();
 float get_float_param(int param_index);

--- a/interpreter.h
+++ b/interpreter.h
@@ -38,24 +38,11 @@
 #ifndef INTERPRETER_H_
 #define INTERPRETER_H_
 
-// These are the error codes produced by commands to pass into interpreter error.
-enum
-{
-    T_SILENT_ERROR = -1, // Special error code designed for ?, h and unimplemented commands that report their own errors.
-    T_OK = 0,            // Normal 'no error' return code.
-    T_OUT_OF_RANGE = 1,
-    T_READ_NOT_SUPPORTED = 2,
-    T_LINE_TOO_LONG = 3,
-    T_UNKNOWN_COMMAND = 4,
-    T_UNEXPECTED_TOKEN = 5
-};
 #define MAX_INPUT_SIZE 14
 extern char inputString[MAX_INPUT_SIZE]; // a String to hold incoming data
 extern int inputIndex;                   // where we are on the input
 void interpreter();
-void init_stored_parameters();
-float get_float_param(int param_index);
-bool get_bool_param(int param_index);
+
 int decode_input_value(int index);
 
 #endif /* INTERPRETER_H_ */

--- a/motor_control.cpp
+++ b/motor_control.cpp
@@ -36,28 +36,32 @@
 #include "pid_v1.h"
 #include "public.h"
 #include "robot_config.h"
+#include "settings.h"
 #include <Arduino.h>
 /***
  * Global variables
  */
 
-float fwd_kp = 0.010;
-float fwd_ki = 0.5;
-float fwd_kd = 0.000;
+// float fwd_kp = 0.010;
+// float fwd_ki = 0.5;
+// float fwd_kd = 0.000;
+// float rot_kp = 0.010;
+// float rot_ki = 0.5;
+// float rot_kd = 0.000;
+
 float fwd_set_speed;
 float fwd_volts;
 
-float rot_kp = 0.010;
-float rot_ki = 0.5;
-float rot_kd = 0.000;
 float rot_set_speed;
 float rot_volts;
 
 bool flag_controllers_use_ff = true;
 bool flag_controllers_enabled = true;
 
-PID fwd_controller(&robot_velocity, &fwd_volts, &fwd_set_speed, fwd_kp, fwd_ki, fwd_kd);
-PID rot_controller(&robot_omega, &rot_volts, &rot_set_speed, rot_kp, rot_ki, rot_kd);
+PID fwd_controller(&robot_velocity, &fwd_volts, &fwd_set_speed,
+                   defaults.fwd_kp, defaults.fwd_ki, defaults.fwd_kd);
+PID rot_controller(&robot_omega, &rot_volts, &rot_set_speed,
+                   defaults.rot_kp, defaults.rot_ki, defaults.rot_kd);
 
 enum
 {
@@ -103,17 +107,26 @@ void motorSetup()
     setMotorVolts(0, 0);
     fwd_controller.SetOutputLimits(-6.0, 6.0);
     fwd_controller.SetMode(AUTOMATIC); // turns on the controller. Set to manual for off.
+    Serial.println("Motors");
+    Serial.println(fwd_controller.GetKp(), 3);
+    Serial.println(fwd_controller.GetKi(), 3);
+    Serial.println(fwd_controller.GetKd(), 3);
+    fwd_controller.SetTunings(settings.fwd_kp, settings.fwd_ki, settings.fwd_kd);
+    Serial.println();
+    Serial.println(fwd_controller.GetKp(), 3);
+    Serial.println(fwd_controller.GetKi(), 3);
+    Serial.println(fwd_controller.GetKd(), 3);
     rot_controller.SetOutputLimits(-6.0, 6.0);
     rot_controller.SetMode(AUTOMATIC); // turns on the controller. Set to manual for off.
+    rot_controller.SetTunings(settings.rot_kp, settings.rot_ki, settings.rot_kd);
 }
 
+// TODO: should low battery voltage automatically disable motors?
 void update_motors()
 {
     rot_controller.Compute();
     fwd_controller.Compute();
     // assume both motors behave the same
-    const float k_velocity_ff = (1.0 / 280.0);
-    const float k_bias_ff = (23.0 / 280.0);
 
     float left_volts = 0;
     float right_volts = 0;
@@ -126,8 +139,8 @@ void update_motors()
 
     if (flag_controllers_use_ff)
     {
-        float fwd_ff = fwd_set_speed * k_velocity_ff;
-        float rot_ff = rot_set_speed * (WHEEL_SEPARATION / (2 * 57.29)) * k_velocity_ff;
+        float fwd_ff = fwd_set_speed * settings.k_velocity_ff;
+        float rot_ff = rot_set_speed * (WHEEL_SEPARATION / (2 * 57.29)) * settings.k_velocity_ff;
         // rot_ff = 0;
 
         left_volts += fwd_ff;

--- a/motor_control.cpp
+++ b/motor_control.cpp
@@ -106,10 +106,10 @@ void motorSetup()
 
     setMotorVolts(0, 0);
     fwd_controller.SetOutputLimits(-6.0, 6.0);
-    fwd_controller.SetMode(AUTOMATIC); // turns on the controller. Set to manual for off.
+    fwd_controller.SetMode(MANUAL); // turns on the controller. Set to manual for off.
     fwd_controller.SetTunings(settings.fwd_kp, settings.fwd_ki, settings.fwd_kd);
     rot_controller.SetOutputLimits(-6.0, 6.0);
-    rot_controller.SetMode(AUTOMATIC); // turns on the controller. Set to manual for off.
+    rot_controller.SetMode(MANUAL); // turns on the controller. Set to manual for off.
     rot_controller.SetTunings(settings.rot_kp, settings.rot_ki, settings.rot_kd);
 }
 
@@ -118,7 +118,6 @@ void update_motors()
 {
     rot_controller.Compute();
     fwd_controller.Compute();
-    // assume both motors behave the same
 
     float left_volts = 0;
     float right_volts = 0;
@@ -132,8 +131,7 @@ void update_motors()
     if (flag_controllers_use_ff)
     {
         float fwd_ff = fwd_set_speed * settings.k_velocity_ff;
-        float rot_ff = rot_set_speed * (WHEEL_SEPARATION / (2 * 57.29)) * settings.k_velocity_ff;
-        // rot_ff = 0;
+        float rot_ff = rot_set_speed * (WHEEL_SEPARATION * PI / 360.0) * settings.k_velocity_ff;
 
         left_volts += fwd_ff;
         right_volts += fwd_ff;
@@ -146,8 +144,6 @@ void update_motors()
     {
         setMotorVolts(left_volts, right_volts);
     }
-    // setMotorVolts(1.4, 1.4);
-    // setMotorVolts(0, 0);
 };
 
 void setLeftMotorPWM(int pwm)

--- a/motor_control.cpp
+++ b/motor_control.cpp
@@ -107,15 +107,7 @@ void motorSetup()
     setMotorVolts(0, 0);
     fwd_controller.SetOutputLimits(-6.0, 6.0);
     fwd_controller.SetMode(AUTOMATIC); // turns on the controller. Set to manual for off.
-    Serial.println("Motors");
-    Serial.println(fwd_controller.GetKp(), 3);
-    Serial.println(fwd_controller.GetKi(), 3);
-    Serial.println(fwd_controller.GetKd(), 3);
     fwd_controller.SetTunings(settings.fwd_kp, settings.fwd_ki, settings.fwd_kd);
-    Serial.println();
-    Serial.println(fwd_controller.GetKp(), 3);
-    Serial.println(fwd_controller.GetKi(), 3);
-    Serial.println(fwd_controller.GetKd(), 3);
     rot_controller.SetOutputLimits(-6.0, 6.0);
     rot_controller.SetMode(AUTOMATIC); // turns on the controller. Set to manual for off.
     rot_controller.SetTunings(settings.rot_kp, settings.rot_ki, settings.rot_kd);

--- a/motor_control.cpp
+++ b/motor_control.cpp
@@ -150,7 +150,7 @@ void update_motors()
         right_volts += rot_ff;
     }
 
-    if(flag_controllers_enabled)
+    if (flag_controllers_enabled)
     {
         setMotorVolts(left_volts, right_volts);
     }

--- a/public.h
+++ b/public.h
@@ -3,11 +3,14 @@
 
 #include "pid_v1.h"
 #include "robot_config.h"
+#include "settings.h"
 #include "switches.h"
 #include "tests.h"
 #include "interpreter.h"
 #include <Arduino.h>
 #include <wiring_private.h>
+
+#define NEW_SETTINGS
 
 //
 // provided by systick.cpp

--- a/public.h
+++ b/public.h
@@ -3,7 +3,6 @@
 
 #include "pid_v1.h"
 #include "robot_config.h"
-#include "settings.h"
 #include "switches.h"
 #include "tests.h"
 #include "interpreter.h"
@@ -99,6 +98,17 @@ typedef unsigned time_measure_t;
 #endif
 
 // Other constants
-const int floating_decimal_places = 3;
+const int DEFAULT_DECIMAL_PLACES = 3;
 
+// These are the error codes produced by commands to pass into interpreter error.
+enum
+{
+    T_SILENT_ERROR = -1, // Special error code designed for ?, h and unimplemented commands that report their own errors.
+    T_OK = 0,            // Normal 'no error' return code.
+    T_OUT_OF_RANGE = 1,
+    T_READ_NOT_SUPPORTED = 2,
+    T_LINE_TOO_LONG = 3,
+    T_UNKNOWN_COMMAND = 4,
+    T_UNEXPECTED_TOKEN = 5
+};
 #endif

--- a/read-number.cpp
+++ b/read-number.cpp
@@ -1,34 +1,38 @@
 /*
- * File: read-number.cpp                                                                 *
- * Project: ukmarsey                                                                     *
- * File Created: Thursday, 4th March 2021 2:36:40 pm                                     *
- * Author: Peter Harrison                                                                *
- * -----                                                                                 *
- * Last Modified: Thursday, 4th March 2021 3:08:07 pm                                    *
- * Modified By: Peter Harrison                                                           *
- * -----                                                                                 *
- * MIT License                                                                           *
- *                                                                                       *
- * Copyright (c) 2021 Peter Harrison                                                     *
- *                                                                                       *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of       *
- * this software and associated documentation files (the "Software"), to deal in         *
- * the Software without restriction, including without limitation the rights to          *
- * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies         *
- * of the Software, and to permit persons to whom the Software is furnished to do        *
- * so, subject to the following conditions:                                              *
- *                                                                                       *
- * The above copyright notice and this permission notice shall be included in all        *
- * copies or substantial portions of the Software.                                       *
- *                                                                                       *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR            *
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,              *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE           *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER                *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,         *
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE         *
- * SOFTWARE.                                                                             *
- */
+ * File: read-number.cpp
+ * Project: ukmarsey
+ * File Created: Thursday, 4th March 2021 2:36:40 pm
+ *
+ *   ukmarsey is a machine and human command-based Robot Low-level I/O platform initially targetting UKMARSBot
+ *   For more information see:
+ *       https://github.com/robzed/ukmarsey
+ *       https://ukmars.org/
+ *       https://github.com/ukmars/ukmarsbot
+ *       https://github.com/robzed/pizero_for_ukmarsbot
+ *
+ *  MIT License
+ *
+ *  Copyright (c) 2020-2021 Rob Probin & Peter Harrison
+ *  Copyright (c) 2019-2021 UK Micromouse and Robotics Society
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+*/
 
 #include "read-number.h"
 #include "public.h"

--- a/read-number.cpp
+++ b/read-number.cpp
@@ -1,0 +1,143 @@
+/*
+ * File: read-number.cpp                                                                 *
+ * Project: ukmarsey                                                                     *
+ * File Created: Thursday, 4th March 2021 2:36:40 pm                                     *
+ * Author: Peter Harrison                                                                *
+ * -----                                                                                 *
+ * Last Modified: Thursday, 4th March 2021 3:08:07 pm                                    *
+ * Modified By: Peter Harrison                                                           *
+ * -----                                                                                 *
+ * MIT License                                                                           *
+ *                                                                                       *
+ * Copyright (c) 2021 Peter Harrison                                                     *
+ *                                                                                       *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of       *
+ * this software and associated documentation files (the "Software"), to deal in         *
+ * the Software without restriction, including without limitation the rights to          *
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies         *
+ * of the Software, and to permit persons to whom the Software is furnished to do        *
+ * so, subject to the following conditions:                                              *
+ *                                                                                       *
+ * The above copyright notice and this permission notice shall be included in all        *
+ * copies or substantial portions of the Software.                                       *
+ *                                                                                       *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR            *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,              *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE           *
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER                *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,         *
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE         *
+ * SOFTWARE.                                                                             *
+ */
+
+#include "read-number.h"
+#include "public.h"
+/////////////////////////////////////////////////////////////////////////////
+
+/***
+ * Scan a character array for an integer.
+ * Begin scn at line[pos]
+ * Assumes no leading spaces.
+ * Stops at first non-digit.
+ * MODIFIES pos so that it points to the first non-digit
+ * MODIFIES value ONLY IF a valid integer is converted
+ * RETURNS  boolean status indicating success or error
+ *
+ * optimisations are possible but may not be worth the effort
+ */
+uint8_t read_integer(const char *line, uint8_t *pos, int *value)
+{
+    char *ptr = (char *)line + *pos;
+    char c = *ptr++;
+    bool is_minus = false;
+    uint8_t digits = 0;
+    if (c == '-')
+    {
+        is_minus = true;
+        c = *ptr++;
+    }
+    int32_t number = 0;
+    while (c >= '0' and c <= '9')
+    {
+        if (digits++ < MAX_DIGITS)
+        {
+            number = 10 * number + (c - '0');
+        }
+        c = *ptr++;
+    }
+    *pos = ptr - line - 1;
+    if (digits > 0)
+    {
+
+        *value = is_minus ? -number : number;
+    }
+    return digits;
+}
+/////////////////////////////////////////////////////////////////////////////
+
+/***
+ * Scan a character array for a float.
+ * This is a much simplified and limited version of the library function atof()
+ * It will not convert exponents and has a limited range of valid values.
+ * They should be more than adequate for the robot parameters however.
+ * Begin scan at line[pos]
+ * Assumes no leading spaces.
+ * Only scans MAX_DIGITS characters
+ * Stops at first non-digit, or decimal point.
+ * MODIFIES pos so that it points to the first character after the number
+ * MODIFIES value ONLY IF a valid float is converted
+ * RETURNS  boolean status indicating success or error
+ *
+ * optimisations are possible but may not be worth the effort
+ */
+uint8_t read_float(const char *line, uint8_t *pos, float *value)
+{
+
+    char *ptr = (char *)line + *pos;
+    char c = *ptr++;
+    uint8_t digits = 0;
+
+    bool is_minus = false;
+    if (c == '-')
+    {
+        is_minus = true;
+        c = *ptr++;
+    }
+
+    uint32_t a = 0.0;
+    int exponent = 0;
+    while (c >= '0' and c <= '9')
+    {
+        if (digits++ < MAX_DIGITS)
+        {
+            a = a * 10 + (c - '0');
+        }
+        c = *ptr++;
+    };
+    if (c == '.')
+    {
+        c = *ptr++;
+        while (c >= '0' and c <= '9')
+        {
+            if (digits++ < MAX_DIGITS)
+            {
+                a = a * 10 + (c - '0');
+                exponent = exponent - 1;
+            }
+            c = *ptr++;
+        }
+    }
+
+    *pos = ptr - line - 1;
+    float b = a;
+    while (exponent < 0)
+    {
+        b *= 0.1;
+        exponent++;
+    }
+    if (digits > 0)
+    {
+        *value = is_minus ? -b : b;
+    }
+    return digits;
+}

--- a/read-number.h
+++ b/read-number.h
@@ -1,34 +1,38 @@
 /*
- * File: read-number.h                                                                   *
- * Project: ukmarsey                                                                     *
- * File Created: Thursday, 4th March 2021 2:36:30 pm                                     *
- * Author: Peter Harrison                                                                *
- * -----                                                                                 *
- * Last Modified: Thursday, 4th March 2021 3:06:26 pm                                    *
- * Modified By: Peter Harrison                                                           *
- * -----                                                                                 *
- * MIT License                                                                           *
- *                                                                                       *
- * Copyright (c) 2021 Peter Harrison                                                     *
- *                                                                                       *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of       *
- * this software and associated documentation files (the "Software"), to deal in         *
- * the Software without restriction, including without limitation the rights to          *
- * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies         *
- * of the Software, and to permit persons to whom the Software is furnished to do        *
- * so, subject to the following conditions:                                              *
- *                                                                                       *
- * The above copyright notice and this permission notice shall be included in all        *
- * copies or substantial portions of the Software.                                       *
- *                                                                                       *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR            *
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,              *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE           *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER                *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,         *
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE         *
- * SOFTWARE.                                                                             *
- */
+ * File: read-number.cpp
+ * Project: ukmarsey
+ * File Created: Thursday, 4th March 2021 2:36:40 pm
+ *
+ *   ukmarsey is a machine and human command-based Robot Low-level I/O platform initially targetting UKMARSBot
+ *   For more information see:
+ *       https://github.com/robzed/ukmarsey
+ *       https://ukmars.org/
+ *       https://github.com/ukmars/ukmarsbot
+ *       https://github.com/robzed/pizero_for_ukmarsbot
+ *
+ *  MIT License
+ *
+ *  Copyright (c) 2020-2021 Rob Probin & Peter Harrison
+ *  Copyright (c) 2019-2021 UK Micromouse and Robotics Society
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+*/
 #ifndef READ_NUMBER_H
 #define READ_NUMBER_H
 

--- a/read-number.h
+++ b/read-number.h
@@ -1,0 +1,80 @@
+/*
+ * File: read-number.h                                                                   *
+ * Project: ukmarsey                                                                     *
+ * File Created: Thursday, 4th March 2021 2:36:30 pm                                     *
+ * Author: Peter Harrison                                                                *
+ * -----                                                                                 *
+ * Last Modified: Thursday, 4th March 2021 3:06:26 pm                                    *
+ * Modified By: Peter Harrison                                                           *
+ * -----                                                                                 *
+ * MIT License                                                                           *
+ *                                                                                       *
+ * Copyright (c) 2021 Peter Harrison                                                     *
+ *                                                                                       *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of       *
+ * this software and associated documentation files (the "Software"), to deal in         *
+ * the Software without restriction, including without limitation the rights to          *
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies         *
+ * of the Software, and to permit persons to whom the Software is furnished to do        *
+ * so, subject to the following conditions:                                              *
+ *                                                                                       *
+ * The above copyright notice and this permission notice shall be included in all        *
+ * copies or substantial portions of the Software.                                       *
+ *                                                                                       *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR            *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,              *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE           *
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER                *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,         *
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE         *
+ * SOFTWARE.                                                                             *
+ */
+#ifndef READ_NUMBER_H
+#define READ_NUMBER_H
+
+#include <Arduino.h>
+
+/***
+ * Numeric input parsers
+ *
+ * Each is provided with
+ *
+ *   line  - a pointer to a character array
+ *   pos   - a pointer to a position in that character array
+ *   value - a pointer to a variable of type float or integer
+ *
+ * The converters try to extract the value of a number starting at line[pos].
+ * Conversion continues until a non-numeric character is found.
+ * Numbers may have an optional leading '-' but no whitespace.
+ *
+ * On exit,
+ *
+ *  - the value variable is updated with teh converted number
+ *  - pos is updated to point to the first character after the number
+ *
+ * The return value is the number of digits converted - excluding any leading '-'
+ *
+ * If no number is found, the function will
+ *  - return zero
+ *  - not change the value of pos
+ *  - not change the contents of the variable 'value'
+ *
+ * There is no checking done to ensure the charactar array bounds are not
+ * exceeded.
+ *
+ * Only the first MAX_DIGITS numerical characters will be converted though
+ * scanning will continue until all numeric digits have been used.
+ *
+ * read_integer() will stop scanning at a decimal point.
+ *
+ * It is quite possible that only read_float() is really needed if it is
+ * accepatble for ints to be assigned a truncated floating point value
+ */
+
+// floats have no more than 8 significant digits
+#define MAX_DIGITS 8
+
+uint8_t read_integer(const char *line, uint8_t *pos, int *value);
+uint8_t read_float(const char *line, uint8_t *pos, float *value);
+
+#endif

--- a/robot_config_sample.h
+++ b/robot_config_sample.h
@@ -62,7 +62,6 @@ const float MAX_MOTOR_VOLTS = 6.0f;
 const float LOOP_FREQUENCY = 500.0;                //Hz
 const float LOOP_INTERVAL = 1.0f / LOOP_FREQUENCY; //seconds
 
-
 // Motor controller constants
 // These are the defaults that will be loaded into settings
 const float SPEED_FF = (1.0 / 280.0);

--- a/robot_config_sample.h
+++ b/robot_config_sample.h
@@ -61,4 +61,17 @@ const float MAX_MOTOR_VOLTS = 6.0f;
 
 const float LOOP_FREQUENCY = 500.0;                //Hz
 const float LOOP_INTERVAL = 1.0f / LOOP_FREQUENCY; //seconds
+
+
+// Motor controller constants
+// These are the defaults that will be loaded into settings
+const float SPEED_FF = (1.0 / 280.0);
+const float BIAS_FF = (23.0 / 280.0);
+const float FWD_KP = 0.010;
+const float FWD_KI = 0.500;
+const float FWD_KD = 0.000;
+const float ROT_KP = 0.010;
+const float ROT_KI = 0.500;
+const float ROT_KD = 0.010;
+
 #endif

--- a/settings.cpp
+++ b/settings.cpp
@@ -1,32 +1,41 @@
-/***********************************************************************
- * Created by Peter Harrison on 2019-06-10.
- * Copyright (c) 2019 Peter Harrison
- *
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the
- * "Software"), to deal in the Software without restriction, including
- * without l> imitation the rights to use, copy, modify, merge, publish,
- * distribute, sublicense, and/or sell copies of the Software, and to
- * permit persons to whom the Software is furnished to do so, subject to
- * the following conditions:
- *
- * The above copyright notice and this permission notice shall be included
- * in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
- * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
- * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
- * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
- * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- *
- **************************************************************************/
+/*
+ * File: settings.cpp                                                                    *
+ * Project: settings-test                                                                *
+ * File Created: Tuesday, 2nd March 2021 2:41:08 pm                                      *
+ * Author: Peter Harrison                                                                *
+ * -----                                                                                 *
+ * Last Modified: Thursday, 4th March 2021 2:25:14 pm                                    *
+ * Modified By: Peter Harrison                                                           *
+ * -----                                                                                 *
+ * Copyright 2017 - 2021 Peter harrison, Helicron                                        *
+ * -----                                                                                 *
+ * MIT License                                                                           *
+ *                                                                                       *
+ * Copyright (c) 2021 Peter harrison                                                     *
+ *                                                                                       *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of       *
+ * this software and associated documentation files (the "Software"), to deal in         *
+ * the Software without restriction, including without limitation the rights to          *
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies         *
+ * of the Software, and to permit persons to whom the Software is furnished to do        *
+ * so, subject to the following conditions:                                              *
+ *                                                                                       *
+ * The above copyright notice and this permission notice shall be included in all        *
+ * copies or substantial portions of the Software.                                       *
+ *                                                                                       *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR            *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,              *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE           *
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER                *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,         *
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE         *
+ * SOFTWARE.                                                                             *
+ */
 
 #include "settings.h"
 #include "EEPROM.h"
 #include <Arduino.h>
+#include <util/crc16.h>
 // TODO: read and write the setting in EEPROM
 
 // create arrays holding the details of each setting in flash
@@ -119,7 +128,11 @@ void dump_settings(const int dp)
     Serial.println();
     for (int i = 0; i < get_settings_count(); i++)
     {
-        print_setting(i, dp);
+        Serial.print('$');
+        Serial.print(i);
+        Serial.print('=');
+        print_setting_value(i, dp);
+        Serial.println();
     }
 }
 
@@ -153,17 +166,49 @@ void load_settings_from_eeprom(bool verbose)
 }
 
 /***
+ * be sure the buffer has enough space
+ */
+int get_setting_name(int i, char *s)
+{
+    // Necessary casts and dereferencing,
+    strncpy_P(s, (char *)pgm_read_word(&(variableString[i])), 31);
+    return 0;
+}
+void print_setting(int i, const int dp)
+{
+    if (i >= get_settings_count())
+    {
+        return;
+    }
+    Serial.print('$');
+    Serial.print(i);
+    Serial.print('=');
+    print_setting_value(i, dp);
+}
+
+void print_setting_details(const int i, const int dp)
+{
+    print_setting_type(i);
+    Serial.print(' ');
+    print_setting_name(i);
+    Serial.print(' ');
+    Serial.print('=');
+    Serial.print(' ');
+    print_setting_value(i, dp);
+}
+
+/***
  * Utility function to send details of a single settings variable over
  * the serial device.
  *
  * The variable is identified by its index, i.
  */
-void print_setting(const int i, const int dp)
+void print_setting_value(const int i, const int dp)
 {
-    Serial.print('$');
-    Serial.print(i);
-    // use '=' as a separator so that we can just stream the output back in if desired
-    Serial.print('=');
+    if (i >= get_settings_count())
+    {
+        return;
+    }
     void *ptr = (void *)pgm_read_word_near(variablePointers + i);
     switch (pgm_read_byte_near(variableType + i))
     {
@@ -171,13 +216,13 @@ void print_setting(const int i, const int dp)
             Serial.print(*reinterpret_cast<float *>(ptr), dp);
             break;
         case T_bool:
-            Serial.print((*reinterpret_cast<bool *>(ptr)) ? F("true") : F("false"));
-            break;
-        case T_char:
-            Serial.print(*reinterpret_cast<char *>(ptr));
+            Serial.print((*reinterpret_cast<bool *>(ptr)) ? 1 : 0);
             break;
         case T_uint32_t:
             Serial.print(*reinterpret_cast<uint32_t *>(ptr));
+            break;
+        case T_uint16_t:
+            Serial.print(*reinterpret_cast<uint16_t *>(ptr));
             break;
         case T_int:
             Serial.print(*reinterpret_cast<int *>(ptr));
@@ -185,13 +230,43 @@ void print_setting(const int i, const int dp)
         default:
             Serial.println(F(" unknown type"));
     }
+}
+
+void print_setting_name(int i)
+{
+    if (i >= get_settings_count())
+    {
+        return;
+    }
     char buffer[32];
-    Serial.print(' ');
-    //TODO: need to make sure the next character is handled by the setting methods as a comment
-    Serial.print('#');
     strncpy_P(buffer, (char *)pgm_read_word(&(variableString[i])), 31); // Necessary casts and dereferencing,
     Serial.print(buffer);
-    Serial.println();
+}
+
+void print_setting_type(const int i)
+{
+    if (i >= get_settings_count())
+    {
+        return;
+    }
+    switch (pgm_read_byte_near(variableType + i))
+    {
+        case T_float:
+            Serial.print(F("float"));
+            break;
+        case T_bool:
+            Serial.print(F("bool"));
+            break;
+        case T_uint32_t:
+            Serial.print(F("uint32_t"));
+            break;
+        case T_uint16_t:
+            Serial.print(F("uint16_t"));
+            break;
+        case T_int: // fall through for ints
+        default:
+            Serial.print(F("int"));
+    }
 }
 
 /***
@@ -203,6 +278,10 @@ void print_setting(const int i, const int dp)
  */
 int write_setting(const int i, const char *valueString)
 {
+    if (i >= get_settings_count())
+    {
+        return -1;
+    }
     void *ptr = (void *)pgm_read_word_near(variablePointers + i);
     switch (pgm_read_byte_near(variableType + i))
     {
@@ -211,9 +290,6 @@ int write_setting(const int i, const char *valueString)
             break;
         case T_bool:
             *reinterpret_cast<bool *>(ptr) = atoi(valueString) ? true : false;
-            break;
-        case T_char:
-            *reinterpret_cast<char *>(ptr) = valueString[0];
             break;
         case T_uint32_t:
             *reinterpret_cast<uint32_t *>(ptr) = atoi(valueString);
@@ -235,4 +311,73 @@ int restore_default_settings()
 {
     memcpy_P(&settings, &defaults, sizeof(defaults));
     return 0;
+}
+
+/***
+ * A simple 16 bit hash function for strings (null terminated character arrays).
+ *
+ * This can be used if needed to create a lookup table for settings names
+ * if other search methods prove too slow. For this purpose, each settings
+ * identfier can be converted to a 16 bit hash vales and the resulting array
+ * stored in RAM.
+ *
+ * Note that setting names are stored in Flash memory where this code cannot
+ * normally see them. Instead, when building the hash table, use the
+ * get_setting_name() function to copy each name into a temporary buffer
+ * before calculating the hash.
+ *
+ * Note that the user will need to find a way to deal with collisions. That is,
+ * there will be more than one string that can generate a given hash. With more
+ * that 65,000 hash values, the risk should be low. In practice, it would be
+ * easier to test all the strings that are to be used and change any that cause
+ * collisions rather than add a way to deal with the collisions.
+ *
+ * When a setting is requested by name, the supplied name is also converted to a
+ * hash and the table can be searched for a corresponding value.
+ *
+ * If the hashes are stored in the same order as the settings then the index of
+ * the matching hash is also the index of the setting in the relevant tables.
+ *
+ * This method consumes 2 bytes of RAM for every setting entry and so it may not
+ * be worth the cost unless speed is very important.
+ *
+ * For a cost of an additional byte, the hash table could hold both the hash and
+ * the setting index. Then, if the hash table were sorted, a fast binary search
+ * could be used to locate the corresponding settings variable.
+ *
+ * It is entirely possible that an 8 bit hash is sufficient for small applications.
+ */
+
+uint16_t hash16(const char *string)
+{
+    // http://www.cse.yorku.ca/~oz/hash.html
+    uint16_t hash = 5381;
+    char c;
+
+    while ((c = *string++) != '\0')
+    {
+        hash = (hash * 33) + c;
+    }
+    return hash;
+}
+
+/***
+ * A basic 8 bit CRC check that can be used to validate blocks of
+ * memory. These may be commands passed back and forth or the values
+ * stored in the settings objects.
+ *
+ * One use might be to compare the default values hard-coded into
+ * the firmware with those stored in EEPROM.
+ *
+ */
+uint8_t crc8(uint8_t *data, unsigned int size)
+{
+    uint8_t checksum = 0;
+    while (size--)
+    {
+        checksum = (checksum << 1) | (checksum >> 7);
+        checksum += *data;
+        data++;
+    }
+    return checksum;
 }

--- a/settings.cpp
+++ b/settings.cpp
@@ -162,10 +162,8 @@ void print_setting(const int i, const int dp)
 {
     Serial.print('$');
     Serial.print(i);
-
-    Serial.print(' ');
-    // Serial.print('=');
-    // Serial.print('=');
+    // use '=' as a separator so that we can just stream the output back in if desired
+    Serial.print('=');
     void *ptr = (void *)pgm_read_word_near(variablePointers + i);
     switch (pgm_read_byte_near(variableType + i))
     {
@@ -189,6 +187,7 @@ void print_setting(const int i, const int dp)
     }
     char buffer[32];
     Serial.print(' ');
+    //TODO: need to make sure the next character is handled by the setting methods as a comment
     Serial.print('#');
     strncpy_P(buffer, (char *)pgm_read_word(&(variableString[i])), 31); // Necessary casts and dereferencing,
     Serial.print(buffer);

--- a/settings.cpp
+++ b/settings.cpp
@@ -1,36 +1,38 @@
 /*
- * File: settings.cpp                                                                    *
- * Project: ukmarsey                                                                     *
- * File Created: Tuesday, 2nd March 2021 2:41:08 pm                                      *
- * Author: Peter Harrison                                                                *
- * -----                                                                                 *
- * Last Modified: Thursday, 4th March 2021 10:12:01 pm                                   *
- * Modified By: Peter Harrison                                                           *
- * -----                                                                                 *
- * Copyright 2017 - 2021 Peter harrison, Helicron                                        *
- * -----                                                                                 *
- * MIT License                                                                           *
- *                                                                                       *
- * Copyright (c) 2021 Peter harrison                                                     *
- *                                                                                       *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of       *
- * this software and associated documentation files (the "Software"), to deal in         *
- * the Software without restriction, including without limitation the rights to          *
- * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies         *
- * of the Software, and to permit persons to whom the Software is furnished to do        *
- * so, subject to the following conditions:                                              *
- *                                                                                       *
- * The above copyright notice and this permission notice shall be included in all        *
- * copies or substantial portions of the Software.                                       *
- *                                                                                       *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR            *
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,              *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE           *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER                *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,         *
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE         *
- * SOFTWARE.                                                                             *
- */
+ * File: settings.cpp
+ * Project: ukmarsey
+ *
+ *  File Created: Tuesday, 2nd March 2021 2:41:08 pm
+ *   ukmarsey is a machine and human command-based Robot Low-level I/O platform initially targetting UKMARSBot
+ *   For more information see:
+ *       https://github.com/robzed/ukmarsey
+ *       https://ukmars.org/
+ *       https://github.com/ukmars/ukmarsbot
+ *       https://github.com/robzed/pizero_for_ukmarsbot
+ *
+ *  MIT License
+ *
+ *  Copyright (c) 2020-2021 Rob Probin & Peter Harrison
+ *  Copyright (c) 2019-2021 UK Micromouse and Robotics Society
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+*/
 
 #include "settings.h"
 #include "EEPROM.h"

--- a/settings.cpp
+++ b/settings.cpp
@@ -1,0 +1,239 @@
+/***********************************************************************
+ * Created by Peter Harrison on 2019-06-10.
+ * Copyright (c) 2019 Peter Harrison
+ *
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without l> imitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ **************************************************************************/
+
+#include "settings.h"
+#include "EEPROM.h"
+#include <Arduino.h>
+// TODO: read and write the setting in EEPROM
+
+// create arrays holding the details of each setting in flash
+
+/***
+ * In flash memory, create an array of strings
+ * to hold the variable names.
+ *
+ * This list would normally only be used to inform the user
+ * during displays or dumps of the setting or perhaps as
+ * part of an interacive configurator.
+ *
+ * The operation has to be done in two parts.
+ *
+ * First each variable name is made into an array of
+ * characters in flash memory.
+ *
+ * Then, another array of pointers to thos strings is created, also in flash
+ */
+
+SETTINGS_PARAMETERS(MAKE_STRINGS);
+
+const char *const variableString[] PROGMEM = {
+    SETTINGS_PARAMETERS(MAKE_NAMES)};
+
+/***
+ * The actual settings are stored in a struct which is fine for normal
+ * use and programs can refer to them in the usual ways like:
+ *    settings.age = 34;
+ *
+ * But, for some use cases, it is convenient to have an array. An array
+ * can't be used to hold the settings because they are of different types
+ * and array indexing is not a very semantic representation. It is also
+ * less efficient.
+ *
+ * For those cases where the user wants to just iterate through the settings,
+ * for example to dump them to the serial port, or read them from a device,
+ * there is an array of pointers to the individual variables in the structure.
+ *
+ * The entries in the array are in the order of declaration in the original
+ * SETTING_PARAMETERS list.
+ *
+ * The array is held in flash since the variables do not move and RAM is
+ * always at a premium.
+ */
+void *const variablePointers[] PROGMEM = {SETTINGS_PARAMETERS(MAKE_POINTERS)};
+
+/***
+ * If the settings variables are to be referred to by index then another
+ * array, also in flash, is needed to tell the code what type is being stored
+ */
+const TypeName variableType[] PROGMEM = {SETTINGS_PARAMETERS(MAKE_TYPES)};
+
+/***
+ * Now store a copy of all the default values in FLASH in case we need them.
+ * These defaults are the values as given in the SETTINGS_PARAMETERS list in the
+ * header file. They cannot be changed at run time
+ */
+const Settings defaults PROGMEM = {SETTINGS_PARAMETERS(MAKE_DEFAULTS)};
+
+/***
+ * Finally, it is time to define the actaul, global working copy of the
+ * settings in RAM and initialise it with the default values.
+ *
+ * This operation gets performed as part of the data initialisation
+ * at start up.
+ *
+ * If there are settings stored in EEPROM that should be used, they will
+ * need to be checked for and loaded from EEPROM in the setup() user code.
+ */
+Settings settings = {SETTINGS_PARAMETERS(MAKE_DEFAULTS)};
+
+/***
+ * All the flash-based arrays are of the same length so any one of them
+ * will do to calculate the number of settings entries.
+ */
+constexpr int SETTINGS_SIZE = sizeof(variableType) / sizeof(variableType[0]);
+const int get_settings_count()
+{
+    static_assert(SETTINGS_SIZE <= SETTING_MAX_SIZE, "SETTINGS TOO BIG");
+    return SETTINGS_SIZE;
+}
+
+/***
+ * utility function to send all the current settings values to the serial
+ * device.
+ */
+void dump_settings(const int dp)
+{
+    Serial.println();
+    for (int i = 0; i < get_settings_count(); i++)
+    {
+        print_setting(i, dp);
+    }
+}
+
+void reset_eeprom_settings_to_defaults()
+{
+    restore_default_settings();
+    save_settings_to_eeprom();
+}
+
+void save_settings_to_eeprom()
+{
+    EEPROM.put(SETTINGS_EEPROM_ADDRESS, settings);
+}
+
+void load_settings_from_eeprom(bool verbose)
+{
+    Settings eeprom_settings;
+    EEPROM.get(SETTINGS_EEPROM_ADDRESS, eeprom_settings);
+    if (eeprom_settings.revision == SETTINGS_REVISION)
+    {
+        settings = eeprom_settings;
+    }
+    else
+    {
+        if (verbose)
+        {
+            Serial.println(F("settings updated."));
+        }
+        reset_eeprom_settings_to_defaults();
+    }
+}
+
+/***
+ * Utility function to send details of a single settings variable over
+ * the serial device.
+ *
+ * The variable is identified by its index, i.
+ */
+void print_setting(const int i, const int dp)
+{
+    Serial.print('$');
+    Serial.print(i);
+
+    Serial.print(' ');
+    // Serial.print('=');
+    // Serial.print('=');
+    void *ptr = (void *)pgm_read_word_near(variablePointers + i);
+    switch (pgm_read_byte_near(variableType + i))
+    {
+        case T_float:
+            Serial.print(*reinterpret_cast<float *>(ptr), dp);
+            break;
+        case T_bool:
+            Serial.print((*reinterpret_cast<bool *>(ptr)) ? F("true") : F("false"));
+            break;
+        case T_char:
+            Serial.print(*reinterpret_cast<char *>(ptr));
+            break;
+        case T_uint32_t:
+            Serial.print(*reinterpret_cast<uint32_t *>(ptr));
+            break;
+        case T_int:
+            Serial.print(*reinterpret_cast<int *>(ptr));
+            break;
+        default:
+            Serial.println(F(" unknown type"));
+    }
+    char buffer[32];
+    Serial.print(' ');
+    Serial.print('#');
+    strncpy_P(buffer, (char *)pgm_read_word(&(variableString[i])), 31); // Necessary casts and dereferencing,
+    Serial.print(buffer);
+    Serial.println();
+}
+
+/***
+ * For convenience, settings can be written to by index number without
+ * knowing the variable name. This can be useful when loading settings
+ * over a serial port since there is not a good way for the code to
+ * locate a variable by name without a slow search of the names table.
+ * (Though that is another approach)
+ */
+int write_setting(const int i, const char *valueString)
+{
+    void *ptr = (void *)pgm_read_word_near(variablePointers + i);
+    switch (pgm_read_byte_near(variableType + i))
+    {
+        case T_float:
+            *reinterpret_cast<float *>(ptr) = (float)atof(valueString);
+            break;
+        case T_bool:
+            *reinterpret_cast<bool *>(ptr) = atoi(valueString) ? true : false;
+            break;
+        case T_char:
+            *reinterpret_cast<char *>(ptr) = valueString[0];
+            break;
+        case T_uint32_t:
+            *reinterpret_cast<uint32_t *>(ptr) = atoi(valueString);
+            break;
+        case T_int:
+            *reinterpret_cast<int *>(ptr) = atoi(valueString);
+            break;
+        default:
+            return -1;
+    }
+    return 0;
+}
+
+/***
+ * A simple, dumb binary copy is a safe way to restore values from flash
+ * because the structures are guaranteed to be identical
+ */
+int restore_default_settings()
+{
+    memcpy_P(&settings, &defaults, sizeof(defaults));
+    return 0;
+}

--- a/settings.cpp
+++ b/settings.cpp
@@ -1,10 +1,10 @@
 /*
  * File: settings.cpp                                                                    *
- * Project: settings-test                                                                *
+ * Project: ukmarsey                                                                     *
  * File Created: Tuesday, 2nd March 2021 2:41:08 pm                                      *
  * Author: Peter Harrison                                                                *
  * -----                                                                                 *
- * Last Modified: Thursday, 4th March 2021 2:25:14 pm                                    *
+ * Last Modified: Thursday, 4th March 2021 3:09:30 pm                                    *
  * Modified By: Peter Harrison                                                           *
  * -----                                                                                 *
  * Copyright 2017 - 2021 Peter harrison, Helicron                                        *

--- a/settings.cpp
+++ b/settings.cpp
@@ -4,7 +4,7 @@
  * File Created: Tuesday, 2nd March 2021 2:41:08 pm                                      *
  * Author: Peter Harrison                                                                *
  * -----                                                                                 *
- * Last Modified: Thursday, 4th March 2021 3:09:30 pm                                    *
+ * Last Modified: Thursday, 4th March 2021 10:12:01 pm                                   *
  * Modified By: Peter Harrison                                                           *
  * -----                                                                                 *
  * Copyright 2017 - 2021 Peter harrison, Helicron                                        *
@@ -136,6 +136,16 @@ void dump_settings(const int dp)
     }
 }
 
+void dump_settings_detail(const int dp)
+{
+    Serial.println();
+    for (int i = 0; i < get_settings_count(); i++)
+    {
+        print_setting_details(i, dp);
+        Serial.println(';');
+    }
+}
+
 void reset_eeprom_settings_to_defaults()
 {
     restore_default_settings();
@@ -160,6 +170,7 @@ void load_settings_from_eeprom(bool verbose)
         if (verbose)
         {
             Serial.println(F("settings updated."));
+            dump_settings_detail();
         }
         reset_eeprom_settings_to_defaults();
     }

--- a/settings.h
+++ b/settings.h
@@ -4,7 +4,7 @@
  * File Created: Tuesday, 2nd March 2021 2:41:08 pm                                      *
  * Author: Peter Harrison                                                                *
  * -----                                                                                 *
- * Last Modified: Thursday, 4th March 2021 3:01:10 pm                                    *
+ * Last Modified: Thursday, 4th March 2021 3:24:38 pm                                    *
  * Modified By: Peter Harrison                                                           *
  * -----                                                                                 *
  * Copyright 2017 - 2021 Peter harrison, Helicron                                        *
@@ -48,6 +48,7 @@
 #ifndef SETTINGS_H
 #define SETTINGS_H
 
+#include "public.h"
 #include <Arduino.h>
 
 /***
@@ -177,8 +178,8 @@ uint8_t crc8(uint8_t *data, unsigned int size);
 int get_setting_name(int i, char *s);
 void print_setting_name(int i);
 void print_setting_type(const int i);
-void print_setting_value(const int i, const int dp = 4);
-void print_setting_details(const int i, const int dp = 4);
+void print_setting_value(const int i, const int dp = DEFAULT_DECIMAL_PLACES);
+void print_setting_details(const int i, const int dp = DEFAULT_DECIMAL_PLACES);
 
 // reading and writing EEPROM settings values and defaults
 int restore_default_settings();
@@ -186,10 +187,10 @@ void save_settings_to_eeprom();
 void load_settings_from_eeprom(bool verbose = false);
 
 // send one setting to the serial device in the form '$n=xxx'
-void print_setting(const int i, const int dp = 4);
+void print_setting(const int i, const int dp = DEFAULT_DECIMAL_PLACES);
 
 // send all to the serial device. sets displayed decimals
-void dump_settings(const int dp = 4);
+void dump_settings(const int dp = DEFAULT_DECIMAL_PLACES);
 
 // write a value to a setting by index number
 int write_setting(const int i, const char *valueString);

--- a/settings.h
+++ b/settings.h
@@ -4,7 +4,7 @@
  * File Created: Tuesday, 2nd March 2021 2:41:08 pm                                      *
  * Author: Peter Harrison                                                                *
  * -----                                                                                 *
- * Last Modified: Thursday, 4th March 2021 3:24:38 pm                                    *
+ * Last Modified: Thursday, 4th March 2021 10:11:13 pm                                   *
  * Modified By: Peter Harrison                                                           *
  * -----                                                                                 *
  * Copyright 2017 - 2021 Peter harrison, Helicron                                        *
@@ -191,6 +191,7 @@ void print_setting(const int i, const int dp = DEFAULT_DECIMAL_PLACES);
 
 // send all to the serial device. sets displayed decimals
 void dump_settings(const int dp = DEFAULT_DECIMAL_PLACES);
+void dump_settings_detail(const int dp = DEFAULT_DECIMAL_PLACES);
 
 // write a value to a setting by index number
 int write_setting(const int i, const char *valueString);

--- a/settings.h
+++ b/settings.h
@@ -1,0 +1,204 @@
+/***********************************************************************
+ * Created by Peter Harrison on 2019-06-10.
+ * Copyright (c) 2019 Peter Harrison
+ *
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without l> imitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Macros derived from
+ * https://stackoverflow.com/questions/201593/is-there-a-simple-way-to-convert-c-enum-to-string/238157#238157
+ *
+ * Storing and reading stuff in FLASH from:
+ * https://www.arduino.cc/reference/en/language/variables/utilities/progmem/
+ *
+ * SPOILERS: Some proper preprocessor arcana here.
+ *           Look away now if you are squeamish
+ *
+ **************************************************************************/
+
+#ifndef SETTINGS_H
+#define SETTINGS_H
+
+#include <Arduino.h>
+
+/***
+ * The revision number can be used to indicate a change to the settins
+ * structure. For example a type change for a variable or the addition or
+ * deletion of a variable.
+ *
+ * Without some kind of indicator like this, the code on the target amy
+ * try to load settings form EEPROM into a settings structure that is
+ * different to the one used to store those settings.
+ *
+ * A change in the revision implies that the defaults have changed in some
+ * significant manner. Normally this is a fundamental change, not just some
+ * different default value for a variable.
+ *
+ * Another reason for a change in the revision might be for a codebase that
+ * runs on a similar but different target.
+ *
+ * The only safe approach when that happens is to resto overwrite any settings
+ * stored in EEPROM with the compiled defaults and load the working settings
+ * with those values.
+ *
+ * NOTE: this means that any custom values in EEPROM will be lost.
+ */
+const int SETTINGS_REVISION = 1002;
+
+/***
+ * The address of the copy stored in EEPROM must be fixed. Although the size of
+ * the structure is known to the compiler, any program using the settings module
+ * may be less aware of how much space is taken from EEPROM storage.
+ *
+ * That means that the user must keep track of the sizes of any objects held
+ * in EEPROM
+ */
+const int SETTINGS_EEPROM_ADDRESS = 0x0000;
+const int SETTING_MAX_SIZE = 64;
+
+/***
+ * First, list  all the types that will be used. Identifiers must all be of the
+ * form T_xxxx where xxxx is any legal type name in C/C++
+ */
+enum TypeName : uint8_t
+{
+    T_char,
+    T_bool,
+    T_uint32_t,
+    T_float,
+    T_int,
+};
+
+// clang-format off
+/***
+ * Now create a list of all the settings variables. For each variable add a line
+ * of the form
+ *    ACTION( type, name, default)  \
+ * where
+ *    type is any valid C/C++ type
+ *    name is a legal C/C++ identifier
+ *    default is the value stored in flash as the default
+ *
+ * This list will be used to generate structures and populate them autumatically
+ * at build time.
+ *
+ * NOTE: if the structure is changes, update SETTINGS_REVISION
+ */
+#define SETTINGS_PARAMETERS(ACTION)                \
+  ACTION(  int,         revision,    SETTINGS_REVISION)        \
+  ACTION(  float,       MaxSpeed,    123.45)     \
+  ACTION(  float,       MaxAccel,     23.456)    \
+  ACTION(  float,       MaxOmega,     34.567)    \
+  ACTION(  float,       MinOmega,     34.567)    \
+  ACTION(  uint32_t,    maxTime,     123456)     \
+  ACTION(  int,         RunCount,    0)        \
+  ACTION(  bool,        JapanRules,  true)       \
+\
+
+/***
+ * These macros are going to be used to generate individual entries in
+ * the data structures that are created later on.
+ *
+ * The macro name will be substituted for the string 'ACTION' in the list above
+ *
+ */
+#define MAKE_STRINGS(       CTYPE,  VAR,   VALUE) const PROGMEM char s_##VAR[] = #VAR;
+#define MAKE_NAMES(         CTYPE,  VAR,   VALUE) s_##VAR,
+#define MAKE_TYPES(         CTYPE,  VAR,   VALUE) T_##CTYPE,
+#define MAKE_DEFAULTS(      CTYPE,  VAR,   VALUE) .VAR = VALUE,
+#define MAKE_STRUCT(        CTYPE,  VAR,   VALUE) CTYPE VAR;
+#define MAKE_POINTERS(      CTYPE,  VAR,   VALUE) reinterpret_cast<void *>(&settings.VAR),
+#define MAKE_CONFIG_ENTRY(  CTYPE,  VAR,   VALUE) {#VAR,T_##CTYPE,reinterpret_cast<void *>(&config.VAR)},
+
+// clang-format on
+
+//
+/***
+ * define the structure that holds the settings
+ *
+ * Uses the MAKE_STRUCT macro to generate one line for each variable in the
+ * parameters list. The result will be a basic struct definition like
+ *
+ * struct Settings {
+ *   float mass;
+ *   int quanity;
+ *   bool loaded;
+ * }
+ */
+struct Settings
+{
+    SETTINGS_PARAMETERS(MAKE_STRUCT)
+};
+
+/***
+ * Now declare the two global instances of the settings
+ */
+extern Settings settings;       // the global working copy in RAM
+extern const Settings defaults; // The coded-in defaults in flash
+extern void *const variablePointers[] PROGMEM;
+extern const TypeName variableType[] PROGMEM;
+const int get_settings_count();
+int restore_default_settings();
+
+void save_settings_to_eeprom();
+void load_settings_from_eeprom(bool verbose = false);
+
+// send all to the serial device. sets displayed decimals
+void dump_settings(const int dp = 2);
+
+// send one setting to the serial device
+void print_setting(const int i, const int dp = 2);
+
+// write a setting by index number
+int write_setting(const int i, const char *valueString);
+/***
+ * The templated version executes much faster because there are
+ * no calls to the ascci_to_xxx converters.
+ *
+ * If the string converting version is never called, you will
+ * save about 1k of flash. Unless you use atof() or atoi() elsewhere.
+ */
+template <class T>
+int write_setting(const int i, const T value)
+{
+    void *ptr = (void *)pgm_read_word_near(variablePointers + i);
+    switch (pgm_read_byte_near(variableType + i))
+    {
+        case T_float:
+            *reinterpret_cast<float *>(ptr) = value;
+            break;
+        case T_bool:
+            *reinterpret_cast<bool *>(ptr) = value;
+            break;
+        case T_char:
+            *reinterpret_cast<char *>(ptr) = value;
+            break;
+        case T_uint32_t:
+            *reinterpret_cast<uint32_t *>(ptr) = value;
+            break;
+        case T_int:
+            *reinterpret_cast<int *>(ptr) = value;
+            break;
+        default:
+            return -1;
+    }
+    return 0;
+}
+#endif //SETTINGS_H

--- a/settings.h
+++ b/settings.h
@@ -1,36 +1,38 @@
 /*
- * File: settings.h                                                                      *
- * Project: ukmarsey                                                                     *
- * File Created: Tuesday, 2nd March 2021 2:41:08 pm                                      *
- * Author: Peter Harrison                                                                *
- * -----                                                                                 *
- * Last Modified: Thursday, 4th March 2021 10:11:13 pm                                   *
- * Modified By: Peter Harrison                                                           *
- * -----                                                                                 *
- * Copyright 2017 - 2021 Peter harrison, Helicron                                        *
- * -----                                                                                 *
- * MIT License                                                                           *
- *                                                                                       *
- * Copyright (c) 2021 Peter harrison                                                     *
- *                                                                                       *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of       *
- * this software and associated documentation files (the "Software"), to deal in         *
- * the Software without restriction, including without limitation the rights to          *
- * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies         *
- * of the Software, and to permit persons to whom the Software is furnished to do        *
- * so, subject to the following conditions:                                              *
- *                                                                                       *
- * The above copyright notice and this permission notice shall be included in all        *
- * copies or substantial portions of the Software.                                       *
- *                                                                                       *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR            *
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,              *
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE           *
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER                *
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,         *
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE         *
- * SOFTWARE.                                                                             *
- */
+ * File: settings.h
+ * Project: ukmarsey
+ *
+ *  File Created: Tuesday, 2nd March 2021 2:41:08 pm
+ *   ukmarsey is a machine and human command-based Robot Low-level I/O platform initially targetting UKMARSBot
+ *   For more information see:
+ *       https://github.com/robzed/ukmarsey
+ *       https://ukmars.org/
+ *       https://github.com/ukmars/ukmarsbot
+ *       https://github.com/robzed/pizero_for_ukmarsbot
+ *
+ *  MIT License
+ *
+ *  Copyright (c) 2020-2021 Rob Probin & Peter Harrison
+ *  Copyright (c) 2019-2021 UK Micromouse and Robotics Society
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+*/
 
 /***********************************************************************
  *

--- a/settings.h
+++ b/settings.h
@@ -50,6 +50,7 @@
 #ifndef SETTINGS_H
 #define SETTINGS_H
 
+#include "robot_config.h"
 #include "public.h"
 #include <Arduino.h>
 
@@ -120,14 +121,14 @@ enum TypeName : uint8_t
  */
 #define SETTINGS_PARAMETERS(ACTION)             \
     ACTION(int, revision, SETTINGS_REVISION)    \
-    ACTION(float, fwd_kp, 0.010)                \
-    ACTION(float, fwd_ki, 0.500)                \
-    ACTION(float, fwd_kd, 0.000)                \
-    ACTION(float, rot_kp, 0.010)                \
-    ACTION(float, rot_ki, 0.500)                \
-    ACTION(float, rot_kd, 0.000)                \
-    ACTION(float, k_velocity_ff, (1.0 / 280.0)) \
-    ACTION(float, k_bias_ff, (23.0 / 280.0))    \
+    ACTION(float, fwd_kp,        FWD_KP  )      \
+    ACTION(float, fwd_ki,        FWD_KI  )      \
+    ACTION(float, fwd_kd,        FWD_KD  )      \
+    ACTION(float, rot_kp,        ROT_KP  )      \
+    ACTION(float, rot_ki,        ROT_KI  )      \
+    ACTION(float, rot_kd,        ROT_KD  )      \
+    ACTION(float, k_velocity_ff, SPEED_FF)      \
+    ACTION(float, k_bias_ff,     BIAS_FF )      \
 \
 
 /***

--- a/tests.cpp
+++ b/tests.cpp
@@ -36,50 +36,14 @@
 #include "interpreter.h"
 #include "stopwatch.h"
 #include "switches.h"
-#define MAX_DIGITS 10
-int32_t read_integer(const char *line, int *pos, int *value)
-{
-    char *ptr = (char *)line + *pos;
-    char c = *ptr++;
-    bool is_minus = false;
-    if (c == '-')
-    {
-        is_minus = true;
-        c = *ptr++;
-    }
-    else if (c == '+')
-    {
-        c = *ptr++;
-    }
-    int32_t number = 0;
-    uint8_t digit_count = 0;
-    while (c >= '0' and c <= '9')
-    {
-        digit_count++;
-        if (digit_count <= MAX_DIGITS)
-        {
-            number = 10 * number + (c - '0'); // number*10 + c
-        }
-        c = *ptr++;
-    }
-    *pos = ptr - line - 1;
-    if (digit_count == 0)
-    {
-        return false;
-    }
-    else
-    {
-        *value = is_minus ? -number : number;
-        return true;
-    }
-}
+#include "read-number.h"
 
 int8_t cmd_test_runner()
 {
     Stopwatch sw;
     int test;
-    int index = 1;
     test = decode_input_value(1);
+    // int index = 1;
     // bool ok = read_integer(inputString, &index, &test);
     Serial.print(F("TEST: "));
     Serial.println(test);

--- a/tests.cpp
+++ b/tests.cpp
@@ -31,12 +31,12 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
   SOFTWARE.
 */
-#include "tests.h"
 #include "interpreter.h"
 #include "public.h"
 #include "read-number.h"
 #include "stopwatch.h"
 #include "switches.h"
+#include "tests.h"
 
 int8_t cmd_test_runner()
 {

--- a/tests.cpp
+++ b/tests.cpp
@@ -33,15 +33,58 @@
 */
 #include "tests.h"
 #include "public.h"
+#include "interpreter.h"
 #include "stopwatch.h"
 #include "switches.h"
+#define MAX_DIGITS 10
+int32_t read_integer(const char *line, int *pos, int *value)
+{
+    char *ptr = (char *)line + *pos;
+    char c = *ptr++;
+    bool is_minus = false;
+    if (c == '-')
+    {
+        is_minus = true;
+        c = *ptr++;
+    }
+    else if (c == '+')
+    {
+        c = *ptr++;
+    }
+    int32_t number = 0;
+    uint8_t digit_count = 0;
+    while (c >= '0' and c <= '9')
+    {
+        digit_count++;
+        if (digit_count <= MAX_DIGITS)
+        {
+            number = 10 * number + (c - '0'); // number*10 + c
+        }
+        c = *ptr++;
+    }
+    *pos = ptr - line - 1;
+    if (digit_count == 0)
+    {
+        return false;
+    }
+    else
+    {
+        *value = is_minus ? -number : number;
+        return true;
+    }
+}
 
 int8_t cmd_test_runner()
 {
-    int test = decode_input_value(1);
+    Stopwatch sw;
+    int test;
+    int index = 1;
+    test = decode_input_value(1);
+    // bool ok = read_integer(inputString, &index, &test);
     Serial.print(F("TEST: "));
     Serial.println(test);
-    test_controllers();
+    Serial.println(sw.split());
+    // test_controllers();
     return T_OK;
 }
 

--- a/tests.cpp
+++ b/tests.cpp
@@ -32,11 +32,11 @@
   SOFTWARE.
 */
 #include "tests.h"
-#include "public.h"
 #include "interpreter.h"
+#include "public.h"
+#include "read-number.h"
 #include "stopwatch.h"
 #include "switches.h"
-#include "read-number.h"
 
 int8_t cmd_test_runner()
 {
@@ -48,7 +48,14 @@ int8_t cmd_test_runner()
     Serial.print(F("TEST: "));
     Serial.println(test);
     Serial.println(sw.split());
-    // test_controllers();
+    switch (test)
+    {
+        case 1:
+            test_controllers();
+            break;
+        default:
+            break;
+    }
     return T_OK;
 }
 
@@ -81,6 +88,7 @@ void log_controller_data()
  */
 void test_controllers()
 {
+    enable_controllers();
     Serial.print(F("CONTROLLER TEST - "));
     bool was_using_ff = flag_controllers_use_ff;
     if (readFunctionSwitch() & 0x01)
@@ -116,6 +124,8 @@ void test_controllers()
     fwd_set_speed = 0;
     rot_set_speed = 0;
     flag_controllers_use_ff = was_using_ff;
+    disable_controllers();
+    setMotorVolts(0, 0);
 };
 
 void test_fwd_feedforward(){

--- a/tests.cpp
+++ b/tests.cpp
@@ -134,7 +134,6 @@ void test_controllers()
     delay(100);
     uint32_t tick = millis() + 10;
     Stopwatch sw;
-    uint32_t start_time = millis();
     while (not button_pressed() && sw.split() < (5 * ONE_SECOND))
     {
         if (millis() > tick)

--- a/ukmarsey.ino
+++ b/ukmarsey.ino
@@ -33,6 +33,7 @@
 */
 
 #include "public.h"
+#include "settings.h"
 #include "stopwatch.h"
 #include <Arduino.h>
 const int REPORTING_INTERVAL = 10;
@@ -45,11 +46,11 @@ void setup()
     pinMode(LED_BUILTIN, OUTPUT);
     Serial.begin(115200);
     Serial.println(F("Hello from ukmarsey"));
+    load_settings_from_eeprom();
     setup_systick();
     sensors_control_setup();
     setup_encoders();
     motorSetup();
-    init_stored_parameters();
     report_time_trigger += REPORTING_INTERVAL;
 }
 

--- a/ukmarsey.ino
+++ b/ukmarsey.ino
@@ -38,11 +38,10 @@
 #include <Arduino.h>
 const int REPORTING_INTERVAL = 10;
 uint32_t report_time_trigger;
-uint8_t PoR_status = 0;
+
+// TODO: we probably need to deal properly with different types of reset
 void setup()
 {
-    PoR_status = MCUSR; // is this erased by bootloader?
-    MCUSR = 0;
     pinMode(LED_BUILTIN, OUTPUT);
     Serial.begin(115200);
     Serial.println(F("Hello from ukmarsey"));

--- a/ukmarsey.ino
+++ b/ukmarsey.ino
@@ -44,7 +44,7 @@ void setup()
 {
     pinMode(LED_BUILTIN, OUTPUT);
     Serial.begin(115200);
-    Serial.println(F("Hello from ukmarsey"));
+    Serial.println(F("\nHello from ukmarsey"));
     load_settings_from_eeprom();
     setup_systick();
     sensors_control_setup();

--- a/ukmarsey.ino
+++ b/ukmarsey.ino
@@ -56,30 +56,5 @@ void setup()
 
 void loop()
 {
-    // fwd_set_speed = 500.0;
-    // rot_set_speed = 0;
-    // handy for simple continuous tests
-    // if (millis() > report_time_trigger)
-    // {
-    //     report_time_trigger += REPORTING_INTERVAL;
-    //     Stopwatch sw;
-    //     Serial.print(millis());
-    //     Serial.print(' ');
-    //     Serial.print(fwd_set_speed);
-    //     Serial.print(' ');
-    //     Serial.print(rot_set_speed);
-    //     Serial.print(' ');
-    //     Serial.print(robot_velocity);
-    //     Serial.print(' ');
-    //     Serial.print(robot_omega);
-    //     Serial.print(' ');
-    //     Serial.print(fwd_volts);
-    //     Serial.print(' ');
-    //     Serial.print(rot_volts); // placeholder for controller voltage
-    //     Serial.print(' ');
-    //     Serial.print(sw.elapsed_time());
-    //     Serial.println();
-    // }
-
     interpreter();
 }


### PR DESCRIPTION
The new settings code is in this PR. I have also updated the REDME to make that correct for the settings command changes.

There are a couple of other cleanups as well.

The read_number functions we discussed are only used in the settings commands.

This is  really a stage in the changes. Once tested, I would like to look at replacing all the existing serial number parsing methods for consistency.

We also need to look at the fact that at least some the settings are going to have values that should come from the robot_config.h file. macro definitions seems simplest. This makes it less likely a user will mess up the settings header and, in any case, these settings are platform dependent.
